### PR TITLE
Add option for g functions to interpolate over frequency

### DIFF
--- a/src/models_utils.py
+++ b/src/models_utils.py
@@ -27,20 +27,43 @@ H_0 = h * 100 * nat.convert(nat.km * nat.s**-1 * nat.Mpc**-1, nat.GeV) # Hubble 
 # freedom from reference 1803.01038
 gs = np.loadtxt(cwd + '/inputs/models/models_data/g_star.dat')
 
-def g_rho(T):
+
+def g_rho(x, is_freq=False):
     """
     | Returns the number of relativistic degrees of 
-    | freedom as a function of T/GeV
+    | freedom as a function of T/GeV or f/Hz.
+
+    :param x: The temperature(s) [GeV] or frequency/frequencies [Hz]
+    :param is_freq: True if `x` is a frequency/frequencies, False if temperature(s)
+    :return: the relativistic degrees of freedom at `x`
     """
-    return np.interp(T, gs[:,0], gs[:,1])
+
+    if is_freq:
+        dof = np.interp(x, gs[:, -1], gs[:, 1])
+
+    else:
+        dof = np.interp(x, gs[:, 0], gs[:, 1])
+
+    return dof
 
 
-def g_s(T):
+def g_s(x, is_freq=False):
     """
-    | Returns the number of entropic relativistic 
-    | degrees of freedom as a function of T/GeV
+    | Returns the number of entropic relativistic degrees of
+    | freedom as a function of T/GeV or f/Hz.
+
+    :param x: The temperature(s) [GeV] or frequency/frequencies [Hz]
+    :param is_freq: True if `x` is a frequency/frequencies, False if temperature(s)
+    :return: the entropic relativistic degrees of freedom at `x`
     """
-    return np.interp(T, gs[:,0], gs[:,3])
+
+    if is_freq:
+        dof = np.interp(x, gs[:, -1], gs[:, 3])
+
+    else:
+        dof = np.interp(x, gs[:, 0], gs[:, 3])
+
+    return dof
 
 
 # -----------------------------------------------------------


### PR DESCRIPTION
The functions `g_rho()` and `g_s()` can now be called on temperatures or frequencies by setting a keyword argument `is_freq`, which defaults to `False.`

Example

`g_rho(data, is_freq=False)`

The above would assume `data` is a temperature(s) in GeV. It would be equivalent to call `g_rho(data)`.

`g_rho(data, is_freq=True)` will treat `data` as a frequency/frequencies.
