### PR TITLE
Richards branch

### DIFF
--- a/src/chains_utils.py
+++ b/src/chains_utils.py
@@ -191,7 +191,6 @@ def plot_posteriors(
     """
 
     if len(np.shape(chains)) == 2:
-        print("Hello There")
         chains = np.array([chains])
         params = np.array([params])
 


### PR DESCRIPTION
Fixed a bug in plot_posteriors in chain_utils.py:
If you don't give params_name as input (so default params_name=None), the else in line 221 fails, since params[0] is a list with n elements, which is being filled by a list with n-5 elements.
Also, when removing all pulsar-noise parameters in line 229, one should not again iterate over idx. Instead, I called the new iteration variable idx2. Otherwise, in line 276 idx will not be 0 and fig will not be initialised, causing an error.