### PR TITLE
White noise

### DIFF
--- a/src/ptarcade/input_handler.py
+++ b/src/ptarcade/input_handler.py
@@ -172,6 +172,7 @@ def check_config(config: ModuleType) -> None:
            "A_bhb_logmin": None,
            "A_bhb_logmax" : None,
            "gamma_bhb" : None,
+           "white_vary" : True,
        }
 
     for par in default.keys():
@@ -241,6 +242,7 @@ def check_config(config: ModuleType) -> None:
         "resume": config.resume,
         "corr": config.corr,
         "bhb_th_prior": config.bhb_th_prior,
+        "white_vary": config.white_vary,
     }
 
     for key, value in bools.items():

--- a/src/ptarcade/sampler.py
+++ b/src/ptarcade/sampler.py
@@ -149,6 +149,7 @@ def initialize_pta(inputs: dict[str, Any], psrs: list[Pulsar] | None, noise_para
             psrs=psrs,
             model=inputs['model'],
             noisedict=noise_params,
+            white_vary=inputs['config'].white_vary,
             pta_dataset=inputs['config'].pta_data,
             bhb_th_prior=inputs['config'].bhb_th_prior,
             gamma_bhb=inputs['config'].gamma_bhb,

--- a/src/ptarcade/signal_builder.py
+++ b/src/ptarcade/signal_builder.py
@@ -368,7 +368,8 @@ def ent_builder(
         efac = parameter.Constant(1.0)
         wn = white_signals.MeasurementNoise(efac=efac)
         s2 = s + wn
-        models.append(s2(p))
+        for p in psrs:
+            models.append(s2(p))
 
     else:
         for p in psrs:


### PR DESCRIPTION
I've made some simulated pulsars with EFAC=1.0. For simplicity, I don't want to use [`enterprise_extensions.blocks.white_noise_block`](https://github.com/astrolamb/enterprise_extensions/blob/541dd1f9a835f790ef4c721d83e80d206b68a941/enterprise_extensions/blocks.py#L39) because I don't include EQUAD. This is in-line with IPTA Mock Data Challenge pulsars.

This update simply lets me use EFAC=1.0 just by setting a new flag in the config file.

@davecwright3 @andrea-mitridate could you advise if I've handled the config input correctly?