### PR TITLE
Check for NaNs in priors

### DIFF
--- a/src/ptarcade/plot_utils.py
+++ b/src/ptarcade/plot_utils.py
@@ -851,7 +851,7 @@ def plot_posteriors(
         filtered_priors = {
             k.replace("_", "-"): v
             for k, v in priors[idx].items()
-            if k.replace("_", "-") in filtered[1] and v is not None
+            if k.replace("_", "-") in filtered[1] and (v is not None or not np.isnan(v))
         }
 
         samples.append(


### PR DESCRIPTION
In order to store data in HDF5 files, we changed `None`'s in our priors to `numpy.nan`'s. This fix takes that into account in the plotting utilities.