### PR TITLE
Added the functionality to perform model comparisons with weighted likelihoods

### DIFF
--- a/src/ptarcade/input_handler.py
+++ b/src/ptarcade/input_handler.py
@@ -172,6 +172,7 @@ def check_config(config: ModuleType) -> None:
            "A_bhb_logmin": None,
            "A_bhb_logmax" : None,
            "gamma_bhb" : None,
+           "ln_modelweight": 0,
        }
 
     for par in default.keys():
@@ -290,6 +291,12 @@ def check_config(config: ModuleType) -> None:
             "A_bhb_logmax, or gamma_bhb will be ignored.\n"
         )
         log.warning(warning)
+
+    if config.mod_sel:
+        message = (
+            "A model comparison with weight " + str(config.ln_modelweight) + " will be performed.\n"
+            )
+        log.info(message)
 
 
 def check_model(model: ModuleType, psrs: list[Pulsar], red_components: int, gwb_components: int, mode: str) -> None:

--- a/src/ptarcade/sampler.py
+++ b/src/ptarcade/sampler.py
@@ -215,7 +215,8 @@ def setup_sampler(
         shutil.rmtree(out_dir)
 
     if inputs['config'].mode == "enterprise":
-        super_model = hypermodel.HyperModel(pta)
+        log_weights = [0,inputs['config'].ln_modelweight]
+        super_model = hypermodel.HyperModel(pta, log_weights=log_weights)
 
         groups = signal_builder.unique_sampling_groups(super_model)
 


### PR DESCRIPTION
The enterprise backend allows setting weights for the individual models in a given hyper-model. I added a parameter `ln_modelweight` in the config file to rescale the likelihood of the 2nd model when performing a model comparison with PTArcade. This allows for a faster convergence of the chain for models that have very distinct likelihoods. 