### PR TITLE
Hotfix - pin Ceffyl version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ scipy = "^1.10.1"
 setuptools = "^67.8.0"
 encor = "^1.1.2"
 llvmlite = "^0.40.0"
-ceffyl = "^1.26"
+ceffyl = "~1.26"
 numba = "^0.57.0"
 tables = "^3.8.0"
 rich = {extras = ["jupyter"], version = "^13.4.2"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ exclude = [
 
 [tool.poetry]
 name = "PTArcade"
-version = "0.1.8"
+version = "0.1.9"
 description = "PTArcade provides an interface to the ENTERPRISE analysis suite and allows for simple implementation of new-physics searches in PTA data."
 readme = "README.md"
 authors = ["Andrea Mitridate <andrea.mitridate@nanograv.org>",]


### PR DESCRIPTION
# The Problem
A new Ceffyl minor version made breaking changes. Our version specification allowed for any minor version 1.X to be installed, so users installing for the first time/updating are getting the newer Ceffyl version.

# Solution
We pin Ceffyl to 1.26.X for now. We will investigate the breaking changes and target a full solution for the v1.0.0 release.

- f1d07b73a0e227b74a6b0d6c15ac25d72be482c0 pins Ceffyl to 1.26
- cff34fbce94bb84a5cde6d7a03151c7a854bcf36 bumps PTArcade 0.1.8 -> 0.1.9