### PR TITLE
Hypermodel wgts

### DIFF
--- a/docs/inputs/model.md
+++ b/docs/inputs/model.md
@@ -193,10 +193,26 @@ The model file can also contain additional (optional) variables that can be used
 :   :octicons-milestone-24: Default: _`False`_ – 
     If set to `True`, the expected signal from SMBHBs will be added to the user-specified signal.
 
+[`mod_sel_wgt`](#+model.mod_sel_wgt){ #+model.mod_sel_wgt }
+
+:   :octicons-milestone-24: Default: _`1.0`_ – 
+    Some models are better supported by the data than others, and a better-supported model is 
+    more likely to be sampled by MCMC. In some cases, this will result in poor sampling of the 
+    less-supported model. To sample both models well, one model may need to be up-weighted or down-weighted. The user can specify a weight on their chosen model to help with sampling. 
+    Selecting a value such that `mod_sel_wgt` $< 1$ down-weights the specified model, while 
+    `mod_sel_wgt` $> 1$ up-weights the specified model. This parameter is only relevant if `mod_sel = True` in the [config file][config].
+
+    !!! Warning "Sample weighting and computing Bayes factors"
+        While weighting the models will result in improved sampling and thus a more accurate 
+        Bayes factor computation, we must correct for the weighting when computing the Bayes 
+        factor. This can be done by also specifying `mod_sel_wgt` in [`get_bf`][ptarcade.chains_utils.compute_bf] 
+        defined in the PTArcade [`chains_utils`][chains_utils] module.
+
 !!! info "NG15 Model Files"
     The model files used in the [NANOGrav 15-year new-physics search][ng15_np] can be found [here][ng15_models].
 
   [out_name]: ../outputs.md
   [ng15_np]:  link_to_papaer
   [ng15_models]: https://zenodo.org/record/8084351
-
+  [config]: config.md
+  [chains_utils]: ../utils/chain_utils.md

--- a/src/ptarcade/chains_utils.py
+++ b/src/ptarcade/chains_utils.py
@@ -467,7 +467,7 @@ def bf_bootstrap(chain: NDArray, burn: int = 0) -> tuple[float, float]:
     return mean, var
 
 
-def compute_bf(chain: NDArray, params: list[str], bootstrap: bool = False) -> tuple[float, float]:  # noqa: FBT001, FBT002
+def compute_bf(chain: NDArray, params: list[str], bootstrap: bool = False, mod_sel_wgt: float = 1.) -> tuple[float, float]:  # noqa: FBT001, FBT002
     """Compute the Bayes factor and estimate its uncertainty.
 
     Parameters
@@ -483,6 +483,9 @@ def compute_bf(chain: NDArray, params: list[str], bootstrap: bool = False) -> tu
     bootstrap : bool, optional
         A flag indicating whether to compute the Bayes factor using a bootstrap method. If True, the Bayes factor will
         be computed using the 'get_bf' function. The bootsrap calculation is significantly slower. Defaults to False.
+    mod_sel_wgt: float, optional
+        If the new physics model was weighted to improve sampling, this will bias the Bayes Factor calculation.
+        If `mod_sel_wgt` was an input in the model file, the value should be supplied here too. Defaults to 1.
 
     Returns
     -------
@@ -520,6 +523,10 @@ def compute_bf(chain: NDArray, params: list[str], bootstrap: bool = False) -> tu
 
     else:
         bf, unc = model_utils.odds_ratio(chain[:, nmodel_idx], models=[0,1])
+
+    # correct for model selection weight
+    bf /= mod_sel_wgt
+    unc /= mod_sel_wgt
 
     return bf, unc
 

--- a/src/ptarcade/input_handler.py
+++ b/src/ptarcade/input_handler.py
@@ -319,9 +319,10 @@ def check_model(model: ModuleType, psrs: list[Pulsar], red_components: int, gwb_
 
     """
     # checks that all the parameters are present in the config file
-    optional = ["name", "smbhb"]
+    optional = ["name", "smbhb", "mod_sel_wgt"]
 
-    optional_default = {"name": "np_model", "smbhb": False}
+    optional_default = {"name": "np_model", "smbhb": False,
+                        "mod_sel_wgt": 1.}
 
     if not (hasattr(model, "parameters")):
         error = "The model file needs to contain a parameter dictionary."

--- a/src/ptarcade/sampler.py
+++ b/src/ptarcade/sampler.py
@@ -215,7 +215,7 @@ def setup_sampler(
         shutil.rmtree(out_dir)
 
     if inputs['config'].mode == "enterprise":
-        super_model = hypermodel.HyperModel(pta)
+        super_model = hypermodel.HyperModel(pta, log_weights=np.log([1., inputs["model"].mod_sel_wgt]))
 
         groups = signal_builder.unique_sampling_groups(super_model)
 


### PR DESCRIPTION
I've added a parameter called `mod_sel_wgt` to up- or down-weight the user-specified model relative to the SMBHB model if a hypermodel is being ran. I've changed the following:

- Included `mod_sel_wgt` as an [input](src/ptarcade/input_handler.py)
- In the [sampler setup](src/ptarcade/sampler.py), `Hypermodel` is now initialised with a `log_weights` array (if `mod_sel=True` in the config file), which defaults to equal weighting if no `mod_sel_wgt` is supplied. The elements of `log_weights` correspond to the indexes of the models.
- A `mod_sel_wgt` parameter included in `compute_bf` in [chain_utils](src/ptarcade/chains_utils.py) to correct for weighting
- Updated [Model file documentation](docs/inputs/model.md)

These updates run on NG15 data, however further testing will need to be done to ensure that it is working as expected.