### PR TITLE
feat(parallel tempering): add config and docs

### DIFF
--- a/docs/getting_started/run.md
+++ b/docs/getting_started/run.md
@@ -65,9 +65,18 @@ If you want an interactive shell, run the following command
 singularity shell ptarcade.sif
 ```
 
+## Using Parallel Tempering
+PTArcade can use [parallel tempering] with a simple modification to your run command. Just prefix `ptarcade` with `mpirun -n <number-of-temperatures>`. For example,
+```sh
+mpirun -n 5 ptarcade -m ./model.py
+```
+will sample your model with 5 temperatures using a geometrically-spaced temperature ladder. This is configurable, see the options in [ptmcmc_sampler_kwargs].
+
   
   [model file]: ../inputs/model.md
   [configuration file]: ../inputs/config.md
   [inputs]: ../inputs/index.md
   [out]: ../inputs/config.md#+config.out_dir
   [name]: ../inputs/model.md#+model.name
+  [parallel tempering]: https://en.wikipedia.org/wiki/Parallel_tempering
+  [ptmcmc_sampler_kwargs]: ../inputs/config.md#+config.ptmcmc_sampler_kwargs

--- a/docs/inputs/config.md
+++ b/docs/inputs/config.md
@@ -220,6 +220,27 @@ with the following parameters in the configuration file:
     Can be assigned to a floating point or integer number to set the value of $\gamma_{\textrm{BHB}}$.
     If `gamma_bhb = None`, a uniform prior between $0$ and $7$ will be used instead.
 
+[`ptmcmc_sampler_kwargs`](#+config.ptmcmc_sampler_kwargs){ #+config.gamma_bhb }
+
+:   :octicons-milestone-24: Default: 
+        ```python
+        ptmcmc_sampler_kwargs = dict(
+            ladder=None,  # User defined temperature ladder
+            Tmin=1,  # Minimum temperature in ladder (default=1)
+            Tmax=1e8,  # Maximum temperature in ladder (default=None)
+            Tskip=100,  # Number of steps between proposed temperature swaps (default=100)
+            isave=1000,  # Write to file every isave samples (default=1000)
+            covUpdate=1000,  # Number of iterations between AM covariance updates (default=1000)
+            maxIter=None,  # Maximum number of iterations for high temperature chains (default=2*self.Niter)
+            thin=10,  # MCMC Samples are recorded every self.thin samples
+            neff=None,  # Number of effective samples to collect before terminating
+            writeHotChains=False,  # Write chains for T!=1
+            hotChain=False,  # Use 1/T=0 for hottest chain (sample from prior)
+        )
+        ```
+        The only option here that is not a default value for `PTMCMCSampler` is `Tmax`. We have set `Tmax` to a value approximating a typical PTA likelihood value. If you use parallel tempering, this ensures that your hottest chain samples mostly from the prior as you would expect.
+
+
 !!! example "Default Configuration File"
 
     If no configuration file is specified by the user, the following file will be 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 requires-python = ">=3.9,<3.13"
 dependencies = [
-    "ptmcmcsampler>=2.1.1,<3.0.0",
+    "ptmcmcsampler>=2.1.4,<3.0.0",
     "mpi4py>=3.1.4,<5.0.0",
     "h5py>=3.8.0,<4.0.0",
     "enterprise-pulsar>=3.4.3,<4.0.0",

--- a/src/ptarcade/data/default_config.py
+++ b/src/ptarcade/data/default_config.py
@@ -18,3 +18,18 @@ bhb_th_prior = True # if set to True the prior for the bhb signal is set to a th
 A_bhb_logmin = None # lower limit for the prior of the bhb signal amplitude. If set to None -18 is used
 A_bhb_logmax = None # upper limit for the prior of the bhb signal amplitude. If set to None -14 is used
 gamma_bhb = None # spectral index for the bhb singal. If set to None it's varied between [0, 7].
+
+# additional PTMCMC configuration
+ptmcmc_sampler_kwargs = dict(
+    ladder=None,  # User defined temperature ladder
+    Tmin=1,  # Minimum temperature in ladder (default=1)
+    Tmax=1e8,  # Maximum temperature in ladder (default=None)
+    Tskip=100,  # Number of steps between proposed temperature swaps (default=100)
+    isave=1000,  # Write to file every isave samples (default=1000)
+    covUpdate=1000,  # Number of iterations between AM covariance updates (default=1000)
+    maxIter=None,  # Maximum number of iterations for high temperature chains (default=2*self.Niter)
+    thin=10,  # MCMC Samples are recorded every self.thin samples
+    neff=None,  # Number of effective samples to collect before terminating
+    writeHotChains=False,  # Write chains for T!=1
+    hotChain=False,  # Use 1/T=0 for hottest chain (sample from prior)
+)

--- a/src/ptarcade/sampler.py
+++ b/src/ptarcade/sampler.py
@@ -173,11 +173,11 @@ def initialize_pta(inputs: dict[str, Any], psrs: list[Pulsar] | None, noise_para
                 corr=inputs['config'].corr,
                 red_components=inputs["config"].red_components,
                 gwb_components=inputs["config"].gwb_components)
-            
+
     elif inputs["config"].mode == "ceffyl":
 
         pta = signal_builder.ceffyl_builder(inputs)
-        
+
     return pta
 
 
@@ -210,7 +210,7 @@ def setup_sampler(
     """
     out_dir = os.path.join(
         inputs["config"].out_dir, inputs["model"].name, f'chain_{input_options["n"]}')
-    
+
     if not inputs["config"].resume and os.path.exists(out_dir):
         shutil.rmtree(out_dir)
 
@@ -299,6 +299,7 @@ def do_sample(inputs: dict[str, Any], sampler: PTSampler, x0: NDArray) -> None:
                 SCAMweight=inputs["config"].scam_weight,
                 AMweight=inputs["config"].am_weight,
                 DEweight=inputs["config"].de_weight,
+                **getattr(inputs["config"], "ptmcmc_sampler_kwargs", {})
             )
         except RuntimeError as e:
             err = ("There was an error while sampling. If this error involves autocorrelation time,\n"

--- a/uv.lock
+++ b/uv.lock
@@ -1673,7 +1673,7 @@ requires-dist = [
     { name = "natpy", specifier = ">=0.1.1,<1.0.0" },
     { name = "numpy", specifier = ">=1.24.3,<3.0.0" },
     { name = "pandas", specifier = ">=2.0.2,<3.0.0" },
-    { name = "ptmcmcsampler", specifier = ">=2.1.1,<3.0.0" },
+    { name = "ptmcmcsampler", specifier = ">=2.1.4,<3.0.0" },
     { name = "pyarrow", specifier = ">=12.0.0" },
     { name = "rich", extras = ["jupyter"], specifier = ">=13.4.2,<15.0.0" },
     { name = "scipy", specifier = ">=1.10.1,<2.0.0" },
@@ -1699,15 +1699,15 @@ docs = [
 
 [[package]]
 name = "ptmcmcsampler"
-version = "2.1.2"
+version = "2.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/9c/d0dec337710b6a81873bfa030ca32b5c02a8a1835eb14ff8107ab3b2d12c/ptmcmcsampler-2.1.2.tar.gz", hash = "sha256:3570c062abb849b0bd1e80c9d35a5cd13f88da7f5006aac98a5dfc0abdcc15bb", size = 1830751 }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/97/74caab69b443bc16ae95ff3f4a1ff54abeba67505140c2b86893e865b624/ptmcmcsampler-2.1.4.tar.gz", hash = "sha256:80d0d0b616a7170de2e0e3ac45fed31ff482da8a66de9ef646ed02b42da7fee9", size = 1831002 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/ff/faa4ad4e28f8b25312da7e897cbb3f199f5198a3c22a6c6df0f281517bd7/ptmcmcsampler-2.1.2-py3-none-any.whl", hash = "sha256:3162c14ec5b9504bf944fffd29d78579b77bea037241b2904531906c62adf654", size = 21350 },
+    { url = "https://files.pythonhosted.org/packages/e5/bd/edd11ec96eb69e20c40f1b4b2afe60a96bc0c69b5c37b48a602477017462/ptmcmcsampler-2.1.4-py3-none-any.whl", hash = "sha256:954892f4d1e24fb0b412cc437dd0b210faaa1500e147ae99b2217956de8a2943", size = 21572 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add parallel tempering configuration options and documentation.

@astrolamb I'd appreciate your eyes on this. I know you've been working with PTMCMC a lot lately. Should we include a check for autocorrelation length by running a pilot chain first? Should we leave that to the user? If you have any other ideas for improvements I'd like to hear them.