### PR TITLE
feat(discovery mode): initial discovery code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "ceffyl>=1.41.1,<1.50",
     "setuptools>=80.0.0",
     "astropy>=5.3.4",
+    "discovery",
+    "numpyro>=0.19.0",
+    "jax>=0.4.30",
 ]
 name = "PTArcade"
 version = "1.1.5"
@@ -169,3 +172,6 @@ exclude = [
 line-length = 120
 target-version = ['py310']
 include = '\.pyi?$'
+
+[tool.uv.sources]
+discovery = { git = "https://github.com/nanograv/discovery.git" }

--- a/src/ptarcade/chains_utils.py
+++ b/src/ptarcade/chains_utils.py
@@ -1,6 +1,7 @@
 """Utilities to be used with output MCMC chains of PTArcade."""
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -268,6 +269,22 @@ def import_to_dataframe(
 
             chains = chains.dropna()
 
+    elif chain_ext == ".feather":
+        chains = pd.read_feather(chains_dir / chain_name)
+        with (chains_dir / "priors.json").open("r") as f:
+            params = json.load(f)
+
+        # this isn't "quicker" right now, but it matches the expected behavior
+        if not quick_import:
+            for col in chains.columns:
+                if "red_noise_log10_A" in col:
+                    params[col] = [-20, -11]
+                elif "red_noise_gamma" in col:
+                    params[col] = [0, 7]
+        else:
+            usecols = [col for col in chains.columns if "red_noise" not in col]
+            chains = chains[usecols]
+        params = pd.DataFrame(params)
 
     print(f"Finished importing   {chains_dir} in {time.time() - start_time:.2f}s")
 

--- a/src/ptarcade/fast_interpolate.py
+++ b/src/ptarcade/fast_interpolate.py
@@ -5,6 +5,7 @@ import h5py
 import numpy as np
 from numpy._typing import _ArrayLikeFloat_co as array_like
 from numpy.typing import NDArray
+import jax.numpy as jnp
 
 
 def load_data(file: str) -> tuple[list[tuple[str, float, float]], NDArray]:
@@ -74,6 +75,50 @@ def interp(info: list[tuple[float, float, array_like]], data: NDArray) -> NDArra
     if getattr(x, "shape", None)==(1,):
         x = x.item() # type: ignore
     (fract, index) = np.modf((x - x0) / dx) # type: ignore
+    index = index.astype(int)
+    # Call ourselves to interpolate over remaining variables if any
+    # then combine results linearly
+    return (interp(info[1:], data[index]) * (1-fract)
+            + interp(info[1:], data[index+1]) * fract)
+
+def jax_interp(info: list[tuple[float, float, array_like]], data: NDArray) -> NDArray:
+    """Do interpolation.
+
+    Called with info: list of (start, step, value) and multidimensional array of data points. Multiple values
+    (in an np.array) are OK for the last value, but not earlier ones or else we will get confusion about
+    array indexes.
+
+    Parameters
+    ----------
+    info : list[tuple[float, float, float]]
+        list of (start, step, value)
+    data : NDArray
+        Multidimensional array of data points. Multiple values (in an np.array) are OK for the last value, but
+        not earlier ones or else we will get confusion about array indexes.
+
+    Returns
+    -------
+    NDArray
+        Interpolated values
+
+    """
+    if len(info) == 0:       # Nothing to do: just return element
+        return data
+    x0, dx, x = info[0]
+    # This function exploits single integer vs array of integer indexing.
+    # Ceffyl returns an array, even if it only contains a single element.
+    # Enterprise doesn't experience this issue.
+    # The type of `x` below can change the type of `index` s.t. it breaks
+    # this function (i.e. `index` will become [3] instead of just 3).
+    # So, here we cast all single element arrays `x` to their
+    # scalar representations.
+    # We use getattr as a quick test for the type (if it's not an
+    # array it won't have the attribute) and to get the shape
+    # if it is an array.
+    # There is probably a much more intelligent way to solve this issue
+    if getattr(x, "shape", None)==(1,):
+        x = x.item() # type: ignore
+    (fract, index) = jnp.modf((x - x0) / dx) # type: ignore
     index = index.astype(int)
     # Call ourselves to interpolate over remaining variables if any
     # then combine results linearly

--- a/src/ptarcade/input_handler.py
+++ b/src/ptarcade/input_handler.py
@@ -220,10 +220,10 @@ def check_config(config: ModuleType) -> None:
         )
         log.error(error)
         raise SystemExit
-            
+
     # checks mod
     if isinstance(config.pta_data, str):
-        if config.mode in ["enterprise", "ceffyl"]:
+        if config.mode in ["enterprise", "ceffyl", "discovery"]:
             pass
         else:
             error = (
@@ -370,11 +370,11 @@ def check_model(model: ModuleType, psrs: list[Pulsar], red_components: int, gwb_
 
     for name, par in model.parameters.items():
         try:
-            x0[name] = par.sample()  # type: ignore
+            x0[name] = par["enterprise_prior_obj"].sample()  # type: ignore
         except AttributeError:
-            x0[name] = par.value  # type: ignore
+            x0[name] = par["enterprise_prior_obj"].value  # type: ignore
         except TypeError:
-            x0[name] = par(name).sample()
+            x0[name] = par["enterprise_prior_obj"](name).sample()
 
     if hasattr(model, "spectrum"):
         if mode == "enterprise":
@@ -443,14 +443,14 @@ def check_model(model: ModuleType, psrs: list[Pulsar], red_components: int, gwb_
 
             log.error(error)
             raise SystemExit
-        
+
     if hasattr(model, "orf"):
         if mode == "ceffyl":
             error = ("It is not possible to use user-specified ORF in ceffyl mode"
                  ", please use PTArcade in enterprise mode to do this.")
             log.error(error)
             raise SystemExit
-        
+
         args = inspect.getfullargspec(model.orf)[0]
         if ['f', 'pos1', 'pos2'] != args[:3]:
             error = ("The first three arguments of the orf function should"

--- a/src/ptarcade/models_utils.py
+++ b/src/ptarcade/models_utils.py
@@ -49,8 +49,11 @@ from functools import cache
 from importlib.resources import files
 from typing import Any, Literal
 
+import jax
+import jax.numpy as jnp
 import natpy as nat
 import numpy as np
+import numpyro.distributions as dist
 import scipy.stats as ss
 from enterprise.signals import parameter
 from enterprise.signals.parameter import function
@@ -114,6 +117,33 @@ def g_rho(x: array_like, is_freq: bool = False) -> array_like:  # noqa: FBT001, 
 
     return dof
 
+def g_rho_jax(x: jax.Array, is_freq: bool = False) -> jax.Array:  # noqa: FBT001, FBT002
+    """Return the number of relativistic degrees of freedom as a function of T/GeV or f/Hz.
+
+    Parameters
+    ----------
+    x : array_like
+        The temperature(s) [GeV] or frequency/frequencies [Hz].
+    is_freq : bool, optional
+        True if `x` is a frequency/frequencies, False if tempe
+rature(s).
+        Defaults to False.
+
+    Returns
+    -------
+    dof : array_like
+        The relativistic degrees of freedom at `x`.
+
+    """
+    if is_freq:
+        dof = jnp.interp(x, gs[:, 1], gs[:, 3])
+
+    else:
+        dof = jnp.interp(x, gs[:, 0], gs[:, 3])
+
+    return dof
+
+
 
 def g_s(x: array_like, is_freq: bool = False) -> array_like:  # noqa: FBT001, FBT002
     """Return the number of entropic relativistic degrees of freedom as a function of T/GeV or f/Hz.
@@ -137,6 +167,31 @@ def g_s(x: array_like, is_freq: bool = False) -> array_like:  # noqa: FBT001, FB
 
     else:
         dof = np.interp(x, gs[:, 0], gs[:, 2])
+
+    return dof
+
+def g_s_jax(x: jax.Array, is_freq: bool = False) -> jax.Array:  # noqa: FBT001, FBT002
+    """Return the number of entropic relativistic degrees of freedom as a function of T/GeV or f/Hz.
+
+    Parameters
+    ----------
+    x : array_like
+        The temperature(s) [GeV] or frequency/frequencies [Hz].
+    is_freq : bool, optional
+        True if `x` is a frequency/frequencies, False if temperature(s).
+        Defaults to False.
+
+    Returns
+    -------
+    dof : array_like
+        The entropic relativistic degrees of freedom at `x`.
+
+    """
+    if is_freq:
+        dof = jnp.interp(x, gs[:, 1], gs[:, 2])
+
+    else:
+        dof = jnp.interp(x, gs[:, 0], gs[:, 2])
 
     return dof
 
@@ -272,7 +327,11 @@ def Gamma(a: float, loc: float, scale: float, size: int | None = None):
 # Helper functions.
 # -----------------------------------------------------------
 
-def omega2cross(omega_hh: Callable[..., NDArray], ceffyl : bool = False) -> Callable[..., NDArray]:
+def omega2cross(
+    omega_hh: Callable[..., NDArray | jax.Array],
+    likelihood: Literal["enterprise", "ceffyl", "discovery"] = "enterprise",
+    model_name: str | None  = None,
+) -> Callable[..., NDArray]:
     """Convert GW energy density.
 
     Converts the GW energy density as a fraction of the closure density into the cross-power spectral density
@@ -281,50 +340,64 @@ def omega2cross(omega_hh: Callable[..., NDArray], ceffyl : bool = False) -> Call
 
     Parameters
     ----------
-    omega_hh : Callable[..., NDArray]
+    omega_hh : Callable[..., NDArray | jax.Array]
         The function that returns the GW energy density as a fraction of the closure density.
 
-    ceffyl: bool
-        If set to tru use a version compatible with ceffyl, if set to false a version compatible with 
-        ENTERPRISE
-
+    likelihood: str
+        Can be "enterprise", "ceffyl", or "discovery"
     Returns
     -------
-    Callable[..., NDArray]
+    Callable[..., NDArray | jax.Array]
         A function that returns the cross-power spectral density as a function of the frequency in Hz.
 
     """
-    if ceffyl:
-        @function
-        def cross(f: NDArray, Tspan: float, **kwargs):
+    match likelihood:
+        case "ceffyl":
 
-            # fraction of the critical density in GWs
-            h2_omega = omega_hh(f, **kwargs)
+            @function
+            def cross(f: NDArray, Tspan: float, **kwargs):
+                # fraction of the critical density in GWs
+                h2_omega = omega_hh(f, **kwargs)
 
-            # characteristic strain spectrum h_c(f)
-            hcf = H_0_Hz / h * np.sqrt(3 * h2_omega / 2) / (np.pi * f)
+                # characteristic strain spectrum h_c(f)
+                hcf = H_0_Hz / h * np.sqrt(3 * h2_omega / 2) / (np.pi * f)
 
-            # cross-power spectral density S(f) (s^3)
-            sf = (hcf**2 / (12 * np.pi**2 * f**3)) / Tspan
+                # cross-power spectral density S(f) (s^3)
+                sf = (hcf**2 / (12 * np.pi**2 * f**3)) / Tspan
 
-            return sf
+                return sf
 
-    else:
-        @function
-        def cross(f: NDArray, components: int = 2, **kwargs):
+        case "enterprise":
 
-            df = np.diff(np.concatenate((np.array([0]), f[::components])))
+            @function
+            def cross(f: NDArray, components: int = 2, **kwargs):
+                df = np.diff(np.concatenate((np.array([0]), f[::components])))
 
-            # fraction of the critical density in GWs
-            h2_omega = omega_hh(f, **kwargs)
+                # fraction of the critical density in GWs
+                h2_omega = omega_hh(f, **kwargs)
 
-            # characteristic strain spectrum h_c(f)
-            hcf = H_0_Hz / h * np.sqrt(3 * h2_omega / 2) / (np.pi * f)
+                # characteristic strain spectrum h_c(f)
+                hcf = H_0_Hz / h * np.sqrt(3 * h2_omega / 2) / (np.pi * f)
 
-            # cross-power spectral density S(f) (s^3)
-            sf = (hcf**2 / (12 * np.pi**2 * f**3)) * np.repeat(df, components)
+                # cross-power spectral density S(f) (s^3)
+                sf = (hcf**2 / (12 * np.pi**2 * f**3)) * np.repeat(df, components)
 
-            return sf
+                return sf
+
+        case "discovery":
+
+            def cross(f: jax.Array, df: jax.Array, *args, **kwargs):
+                kwargs = {key.removeprefix(f"{model.name}_"): val for key, val in kwargs.items()} if kwargs is not None else kwargs
+                # fraction of the critical density in GWs
+                h2_omega = omega_hh(f, *args, **kwargs)
+
+                # characteristic strain spectrum h_c(f)
+                hcf = H_0_Hz / h * jnp.sqrt(3 * h2_omega / 2) / (jnp.pi * f)
+
+                # cross-power spectral density S(f) (s^3)
+                sf = (hcf**2 / (12 * np.pi**2 * f**3)) * df
+
+                return sf
 
     return cross
 
@@ -427,6 +500,37 @@ def freq_at_temp(T: array_like) -> array_like:
 
     return prefactor * sqr_term
 
+def freq_at_temp_jax(T: jax.Array) -> jax.Array:
+    """Find frequency today as function of temperature when GW was horizon size.
+
+    Calculates the GW frequency [Hz] today as a function of the universe temperature [GeV]
+    when the GW was of horizon size.
+
+    Parameters
+    ----------
+    T : array_like
+        The universe temperature [GeV] at the time when the GW was of horizon size.
+
+    Returns
+    -------
+    NDArray
+        The GW frequency [Hz] today that was of horizon size when the universe was at temperature `T` [GeV].
+    """
+    f_0 = H_0_Hz / (2 * np.pi)
+
+    T_ratio = T_0 / T # type: ignore
+    g_ratio = g_rho_0 / g_rho_jax(T) # type: ignore
+    gs_ratio = g_s_0 / g_s_jax(T) # type: ignore
+
+    prefactor = f_0 * (gs_ratio) ** (1 / 3) * T_ratio
+    sqr_term = jnp.sqrt(
+        omega_v
+        + (gs_ratio**-1 * T_ratio**-3 * omega_m)
+        + (g_ratio**-1 * T_ratio**-4 * omega_r)
+    )
+
+    return prefactor * sqr_term
+
 
 def temp_at_freq(f: array_like) -> NDArray:
     """Get the temperature [GeV] of the universe when a gravitational wave of a
@@ -444,6 +548,24 @@ def temp_at_freq(f: array_like) -> NDArray:
 
     """
     return np.interp(f, gs[:, 1], gs[:, 0], left=np.nan, right=np.nan)
+
+
+def temp_at_freq_jax(f: jax.Array) -> jax.Array:
+    """Get the temperature [GeV] of the universe when a gravitational wave of a
+    certain frequency [Hz] today was of horizon size.
+
+    Parameters
+    ----------
+    f : array_like
+        The frequency in Hz today.
+
+    Returns
+    -------
+    NDArray
+        The temperature [GeV] when the GW at frequency `f` [Hz] was of horizon size.
+
+    """
+    return jnp.interp(f, gs[:, 1], gs[:, 0], left=jnp.nan, right=jnp.nan)
 
 
 class ParamDict(UserDict):
@@ -537,4 +659,8 @@ def prior(name: priors_type, *args: Any, **kwargs: Any) -> parameter.Parameter:
     # Store the `common` arg for later use
     prior_obj.common = common
 
-    return prior_obj
+    # return the args
+    return {"name": name, "args": args, "kwargs": kwargs, "enterprise_prior_obj": prior_obj}
+
+def get_numpyro_prior(name, *args, **kwargs):
+    return getattr(dist, name)(*args, **kwargs)

--- a/src/ptarcade/models_utils.py
+++ b/src/ptarcade/models_utils.py
@@ -247,7 +247,7 @@ g_s_0: np.float64 = __g_s_0(T_0)  # entropic relativistic degrees of freedom tod
 # -----------------------------------------------------------
 
 
-def GammaPrior(value: float, a: float, loc: float, scale: float) -> float:
+def GammaPrior(value: float, a: float, beta: float) -> float:
     """Prior function for Gamma parameters.
 
     Parameters
@@ -267,9 +267,9 @@ def GammaPrior(value: float, a: float, loc: float, scale: float) -> float:
         The probability density of the Gamma distribution at `value`.
 
     """
-    return ss.gamma.pdf(value, a, loc, scale)
+    return ss.gamma.pdf(value, a, scale=1/beta)
 
-def GammaSampler(a: float, loc: float, scale: float, size: int | None  = None) -> NDArray:
+def GammaSampler(a: float, beta: float, size: int | None  = None) -> NDArray:
     """Sampling function for Gamma parameters.
 
     Parameters
@@ -289,10 +289,10 @@ def GammaSampler(a: float, loc: float, scale: float, size: int | None  = None) -
         A NumPy array of size `size` containing samples from the Gamma distribution.
 
     """
-    return ss.gamma.rvs(a, loc, scale, size=size)
+    return ss.gamma.rvs(a, scale=1/beta, size=size)
 
 
-def Gamma(a: float, loc: float, scale: float, size: int | None = None):
+def Gamma(a: float,  beta: float, size: int | None = None):
     """Class factory for Gamma parameters.
 
     Parameters
@@ -316,9 +316,9 @@ def Gamma(a: float, loc: float, scale: float, size: int | None = None):
         """Child class of enterprise.signals.parameter.Parameter."""
 
         _size = size
-        _prior = parameter.Function(GammaPrior, a=a, loc=loc, scale=scale)
+        _prior = parameter.Function(GammaPrior, a=a,  beta=beta)
         _sampler = staticmethod(GammaSampler)
-        _typename = parameter._argrepr("Gamma", a=a, loc=loc, scale=scale)
+        _typename = parameter._argrepr("Gamma", a=a, beta=beta)
 
     return Gamma
 
@@ -440,7 +440,7 @@ def prep_data(path: str) -> tuple[list[NDArray], NDArray, NDArray]:
     return grids, omega_grid, par_names
 
 
-def spec_importer(path: str) -> Callable[[NDArray, Any],  NDArray]:
+def spec_importer(path: str, kind:Literal["numpy", "jax"]="numpy") -> Callable[[NDArray, Any],  NDArray]:
     """Import data and create a fast interpolation function.
 
     Interpolate the GWB power spectrum from tabulated data. Return a function that interpolates
@@ -460,12 +460,21 @@ def spec_importer(path: str) -> Callable[[NDArray, Any],  NDArray]:
     info, data = fast_interpolate.load_data(path)
     # info is a list of (name, start, step)
 
-    def spectrum(f: NDArray, **kwargs: Any) -> NDArray:
+    if kind.lower() == "numpy":
+        def spectrum(f: NDArray, **kwargs: Any) -> NDArray:
 
-        # Construct right information format for interpolation
-        return fast_interpolate.interp([(start, step, f if name == 'f' else kwargs[name])
-                                         for (name, start, step) in info],
-                                        data)
+            # Construct right information format for interpolation
+            return fast_interpolate.interp([(start, step, f if name == 'f' else kwargs[name])
+                                            for (name, start, step) in info],
+                                           data)
+    elif kind.lower() == "jax":
+        def spectrum(f: NDArray, **kwargs: Any) -> NDArray:
+
+            # Construct right information format for interpolation
+            return fast_interpolate.jax_interp([(start, step, f if name == 'f' else kwargs[name])
+                                            for (name, start, step) in info],
+                                           data)
+
     return spectrum # type: ignore
 
 

--- a/src/ptarcade/pta_importer.py
+++ b/src/ptarcade/pta_importer.py
@@ -6,7 +6,10 @@ import json
 import logging
 import os
 import pickle
+from pathlib import Path
 
+import discovery as ds
+from astropy.config import get_cache_dir
 from astropy.utils.data import download_file, get_readable_fileobj
 from enterprise.pulsar import Pulsar
 from numpy._typing import _ArrayLikeFloat_co as array_like
@@ -236,3 +239,44 @@ def pta_data_importer(pta_data: str | dict) -> tuple[list[Pulsar], dict | None, 
         raise SystemExit
 
     return psrs, params, emp_dist
+
+def convert_enterprise_pulsars_to_discovery(
+        enterprise_psrs: list[Pulsar], dataset_name: str,  noisedict: dict[str, array_like] | None = None
+) -> list[ds.Pulsar]:
+    """Convert enterprise Pulsar objects to discovery Pulsar objects.
+
+    This function transforms a list of enterprise Pulsar objects into discovery
+    Pulsar format by serializing them to feather format as an intermediate
+    representation. Each enterprise pulsar is converted individually using its
+    to_feather method along with optional noise parameters.
+
+    Parameters
+    ----------
+    enterprise_psrs : list[Pulsar]
+        List of enterprise Pulsar objects to be converted to discovery format.
+    noisedict : dict[str, array_like] or None, optional
+        Dictionary mapping noise parameter names to their values. If provided,
+        these noise parameters are included in the conversion. Default is None.
+
+    Returns
+    -------
+    list[ds.Pulsar]
+        List of discovery Pulsar objects converted from the input enterprise
+        pulsars.
+
+    """
+    discovery_psrs = []
+
+    out_dir = Path(get_cache_dir("ptarcade")) / "feather_pulsars" / dataset_name
+    out_dir.mkdir(exist_ok = True, parents=True)
+    for ep in enterprise_psrs:
+        output_file = out_dir / f"{ep.name}.feather"
+        if output_file.exists():
+            print(f"Loading cached {ep.name}")
+            # You can also pre-load these manually at this location
+            discovery_psrs.append(ds.Pulsar.read_feather(str(output_file)))
+        else:
+            print(f"Converting {ep.name}")
+            discovery_psrs.append(ds.Pulsar.save_feather(ep, str(output_file), noisedict))
+
+    return discovery_psrs

--- a/src/ptarcade/pta_importer.py
+++ b/src/ptarcade/pta_importer.py
@@ -254,6 +254,8 @@ def convert_enterprise_pulsars_to_discovery(
     ----------
     enterprise_psrs : list[Pulsar]
         List of enterprise Pulsar objects to be converted to discovery format.
+    dataset_name: str
+        Name of PTA dataset.
     noisedict : dict[str, array_like] or None, optional
         Dictionary mapping noise parameter names to their values. If provided,
         these noise parameters are included in the conversion. Default is None.
@@ -269,14 +271,24 @@ def convert_enterprise_pulsars_to_discovery(
 
     out_dir = Path(get_cache_dir("ptarcade")) / "feather_pulsars" / dataset_name
     out_dir.mkdir(exist_ok = True, parents=True)
+
     for ep in enterprise_psrs:
         output_file = out_dir / f"{ep.name}.feather"
         if output_file.exists():
-            print(f"Loading cached {ep.name}")
             # You can also pre-load these manually at this location
-            discovery_psrs.append(ds.Pulsar.read_feather(str(output_file)))
-        else:
-            print(f"Converting {ep.name}")
-            discovery_psrs.append(ds.Pulsar.save_feather(ep, str(output_file), noisedict))
+            # Not going to load them now. Some pulsars take a large amount of memory to convert.
+            # So, we'll hold off on actually loading anything until after we convert.
+            continue
+        msg = f"Converting {ep.name}"
+        log.info(msg)
+        ds.Pulsar.save_feather(ep, str(output_file), noisedict)
+
+    for ep in enterprise_psrs:
+        output_file = out_dir / f"{ep.name}.feather"
+        msg = f"Loading {ep.name}"
+        log.info(msg)
+        # You can also pre-load these manually at this location
+        # Load now that everything is done being converted to feather.
+        discovery_psrs.append(ds.Pulsar.read_feather(str(output_file)))
 
     return discovery_psrs

--- a/src/ptarcade/sampler.py
+++ b/src/ptarcade/sampler.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 import os
 import warnings
 
+import numpyro
+
 from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from ptarcade import pta_importer
 
 warnings.filterwarnings('ignore', category=AstropyDeprecationWarning)
 
+import json
 import logging
 import platform
 import shutil
@@ -21,7 +26,11 @@ import erfa
 
 sys.modules["astropy.erfa"] = erfa
 
+from pathlib import Path
+
+import jax
 import numpy as np
+import pandas as pd
 import rich
 from ceffyl import Sampler
 from enterprise.pulsar import Pulsar
@@ -34,12 +43,12 @@ from rich import print
 from rich.console import Console
 from rich.panel import Panel
 
-from ptarcade import input_handler, pta_importer, signal_builder
+from ptarcade import console, input_handler, pta_importer, signal_builder
 from ptarcade.input_handler import bcolors
 from ptarcade.models_utils import ParamDict
-from ptarcade import console
 
 log = logging.getLogger("rich")
+numpyro.enable_x64(use_x64=True)
 
 def cpu_model() -> str:
     """Get CPU info."""
@@ -82,7 +91,7 @@ def get_user_args() -> tuple[dict[str, ModuleType], dict[str, Any]] :
 
     if not hasattr(inputs["model"], "group"):
         pars_dic = inputs["model"].parameters
-        group = [par for par in pars_dic.keys() if pars_dic[par].common]
+        group = [par for par in pars_dic if pars_dic[par]["enterprise_prior_obj"].common]
 
         setattr(inputs["model"], "group", group)
 
@@ -173,11 +182,24 @@ def initialize_pta(inputs: dict[str, Any], psrs: list[Pulsar] | None, noise_para
                 corr=inputs['config'].corr,
                 red_components=inputs["config"].red_components,
                 gwb_components=inputs["config"].gwb_components)
-            
+
     elif inputs["config"].mode == "ceffyl":
 
         pta = signal_builder.ceffyl_builder(inputs)
-        
+
+    elif inputs["config"].mode == "discovery":
+        discovery_psrs = pta_importer.convert_enterprise_pulsars_to_discovery(
+            psrs, inputs["config"].pta_data, noisedict=noise_params
+        )
+        pta = signal_builder.discovery_builder(
+            psrs=discovery_psrs,
+            model=inputs["model"],
+            corr=inputs["config"].corr,
+            red_components=inputs["config"].red_components,
+            gwb_components=inputs["config"].gwb_components,
+        )
+        pta.psrs = discovery_psrs
+
     return pta
 
 
@@ -210,7 +232,7 @@ def setup_sampler(
     """
     out_dir = os.path.join(
         inputs["config"].out_dir, inputs["model"].name, f'chain_{input_options["n"]}')
-    
+
     if not inputs["config"].resume and os.path.exists(out_dir):
         shutil.rmtree(out_dir)
 
@@ -246,6 +268,10 @@ def setup_sampler(
             jump=False)
 
         x0 = pta.initial_samples()
+    elif inputs["config"].mode == "discovery":
+        numpyro_model = signal_builder.discovery_numpyro_model_builder(pta.psrs, inputs, pta)
+        sampler = numpyro.infer.NUTS(numpyro_model)
+        x0 = None
 
     return sampler, x0
 
@@ -292,21 +318,35 @@ def do_sample(inputs: dict[str, Any], sampler: PTSampler, x0: NDArray) -> None:
             module="enterprise.signals.parameter",
             lineno=62,
         )
-        try:
-            sampler.sample(
-                x0,
-                N_samples,
-                SCAMweight=inputs["config"].scam_weight,
-                AMweight=inputs["config"].am_weight,
-                DEweight=inputs["config"].de_weight,
+        if inputs["config"].mode in ["enteprise", "ceffyl"]:
+            try:
+                sampler.sample(
+                    x0,
+                    N_samples,
+                    SCAMweight=inputs["config"].scam_weight,
+                    AMweight=inputs["config"].am_weight,
+                    DEweight=inputs["config"].de_weight,
+                )
+            except RuntimeError as e:
+                err = ("There was an error while sampling. If this error involves autocorrelation time,\n"
+                      "a temporary fix is to increase the number of samples in the configuration file.\n"
+                      "We are actively working to upgrade the autocorrelation routines in our sampler.\n\n")
+                console.print("\n\n")
+                log.exception(err)
+                raise SystemExit from None
+        elif inputs["config"].mode == "discovery":
+            mcmc = numpyro.infer.MCMC(
+                sampler, num_chains=1, progress_bar=True, num_warmup=N_samples // 4, num_samples=N_samples
             )
-        except RuntimeError as e:
-            err = ("There was an error while sampling. If this error involves autocorrelation time,\n"
-                  "a temporary fix is to increase the number of samples in the configuration file.\n"
-                  "We are actively working to upgrade the autocorrelation routines in our sampler.\n\n")
-            console.print("\n\n")
-            log.exception(err)
-            raise SystemExit from None
+            mcmc.run(jax.random.key(42))
+            samples_df = pd.DataFrame(mcmc.get_samples())
+            parameter_dict = inputs["model"].parameters
+            prior_dict = {key: np.array(val["args"]).tolist() for key,val in parameter_dict.items()}
+            out_dir = Path(inputs["config"].out_dir)
+            out_dir.mkdir(exist_ok=True, parents=True)
+            samples_df.to_feather(out_dir / "chain_1.feather")
+            with (out_dir / "priors.json").open("w") as f:
+                json.dump(prior_dict, f)
 
     console.print()
     console.print(Panel.fit("[bold green]Done sampling[/]", border_style="green"))
@@ -336,7 +376,7 @@ def main():
     noise_params = None
     emp_dist = None
 
-    if inputs["config"].mode == "enterprise":
+    if inputs["config"].mode in ["enterprise", "discovery"]:
         with console.status("Loading Pulsars and noise data...", spinner="bouncingBall"):
 
             # import pta data
@@ -345,14 +385,14 @@ def main():
             console.print(f"[bold green]Done loading [blue]{len(psrs)}[/] Pulsars and noise data :heavy_check_mark:\n")
 
 
-    with console.status("Initializing PTA...", spinner="bouncingBall"):
-        pta = initialize_pta(inputs, psrs, noise_params)
-        console.print("[bold green]Done initializing PTA :heavy_check_mark:\n")
+    #with console.status("Initializing PTA...", spinner="bouncingBall"):
+    pta = initialize_pta(inputs, psrs, noise_params)
+    console.print("[bold green]Done initializing PTA :heavy_check_mark:\n")
 
 
-    with console.status("Initializing Sampler...", spinner="bouncingBall"):
-        sampler, x0 = setup_sampler(inputs, input_options, pta, emp_dist)
-        console.print("[bold green]Done initializing Sampler :heavy_check_mark:\n")
+    #with console.status("Initializing Sampler...", spinner="bouncingBall"):
+    sampler, x0 = setup_sampler(inputs, input_options, pta, emp_dist)
+    console.print("[bold green]Done initializing Sampler :heavy_check_mark:\n")
 
     console.print("Done with all initializtions.\nSetup times (including first sample) {:.2f} seconds real, {:.2f} seconds CPU\n".format(
         time.perf_counter()-start_real, time.process_time()-start_cpu));

--- a/src/ptarcade/signal_builder.py
+++ b/src/ptarcade/signal_builder.py
@@ -582,10 +582,43 @@ def discovery_builder(
     red_components: int = 30,
     gwb_components: int = 14,
 ) -> ds.ArrayLikelihood:
-    globalgp_psd = aux.omega2cross(model.spectrum, likelihood="discovery")
-    globalgp_psd.__signature__ = inspect.signature(model.spectrum)
 
     Tspan = ds.getspan(psrs)
+
+    # stochastic process
+    if hasattr(model, "spectrum"):
+        globalgp_psd = aux.omega2cross(model.spectrum, likelihood="discovery")
+        globalgp_psd.__signature__ = inspect.signature(model.spectrum)
+        pslmodels = (
+            ds.PulsarLikelihood(
+                [
+                    psr.residuals,
+                    ds.makenoise_measurement(psr, psr.noisedict),
+                    ds.makegp_ecorr(psr, psr.noisedict),
+                    ds.makegp_timing(psr, svd=True),
+                ]
+            )
+            for psr in psrs
+        )
+
+        rngp = ds.makecommongp_fourier(psrs, ds.powerlaw, red_components, T=Tspan, name="red_noise")
+        if corr:
+            hdgp = ds.makeglobalgp_fourier(psrs, globalgp_psd, ds.hd_orf, gwb_components, T=Tspan, name=model.name)
+            return ds.ArrayLikelihood(pslmodels, commongp=rngp, globalgp=hdgp)
+
+        curngp = ds.makecommongp_fourier(
+            psrs,
+            globalgp_psd,
+            gwb_components,
+            T=Tspan,
+            common=list(model.parameters),
+            name=model.name,
+        )
+        return ds.ArrayLikelihood(pslmodels, commongp=[rngp, curngp])
+
+    # deterministic delays
+    delay_func = model.signal
+    delay_func.__signature__ = inspect.signature(model.signal)
 
     pslmodels = (
         ds.PulsarLikelihood(
@@ -594,26 +627,23 @@ def discovery_builder(
                 ds.makenoise_measurement(psr, psr.noisedict),
                 ds.makegp_ecorr(psr, psr.noisedict),
                 ds.makegp_timing(psr, svd=True),
+                ds.makedelay(
+                    psr,
+                    delay_func,
+                    common=[
+                        par
+                        for par, val in model.parameters.items()
+                        if getattr(val["enterprise_prior_obj"], "common", True) # return false if no "common" attribute
+                    ],
+                    name=model.name,
+                ),
             ]
         )
         for psr in psrs
     )
 
     rngp = ds.makecommongp_fourier(psrs, ds.powerlaw, red_components, T=Tspan, name="red_noise")
-    if corr:
-        hdgp = ds.makeglobalgp_fourier(psrs, globalgp_psd, ds.hd_orf, gwb_components, T=Tspan, name=model.name)
-        return ds.ArrayLikelihood(pslmodels, commongp=rngp, globalgp=hdgp)
-
-    curngp = ds.makecommongp_fourier(
-        psrs,
-        globalgp_psd,
-        gwb_components,
-        T=Tspan,
-        common=list(model.parameters),
-        name=model.name,
-    )
-    return ds.ArrayLikelihood(pslmodels, commongp=[rngp, curngp])
-
+    return ds.ArrayLikelihood(pslmodels, commongp=rngp)
 
 def discovery_numpyro_model_builder(
     psrs: list[ds.Pulsar],
@@ -629,7 +659,6 @@ def discovery_numpyro_model_builder(
     ln_likelihood = likelihood_obj.logL
     params = ln_likelihood.params
 
-
     red_noise_gamma_params = []
     red_noise_amp_params = []
 
@@ -639,12 +668,26 @@ def discovery_numpyro_model_builder(
         elif "red_noise_gamma" in p:
             red_noise_gamma_params.append(p)
 
+    import ipdb; ipdb.set_trace()
     def discovery_model():
         # Get new physics priors
         params = {
-            (f"{inputs['model'].name}_{par}" if inputs["config"].corr else par): numpyro.sample(par, aux.get_numpyro_prior(val["name"], *val["args"], **val["kwargs"]))
+            (f"{inputs['model'].name}_{par}" if inputs["config"].corr else par): numpyro.sample(
+                par, aux.get_numpyro_prior(val["name"], *val["args"], **val["kwargs"])
+            )
             for par, val in inputs["model"].parameters.items()
+            if getattr(val["enterprise_prior_obj"], "common", True)
         }
+        params.update(
+            {
+                (name:=f"{psr.name}_{inputs['model'].name}_{par}"): numpyro.sample(
+                    name, aux.get_numpyro_prior(val["name"], *val["args"], **val["kwargs"])
+                )
+                for par, val in inputs["model"].parameters.items()
+                if not getattr(val["enterprise_prior_obj"], "common", False)
+                for psr in psrs
+            }
+        )
 
         # Pulsar red noise priors
         for amp, gam in zip(red_noise_amp_params, red_noise_gamma_params, strict=True):
@@ -656,5 +699,4 @@ def discovery_numpyro_model_builder(
             )
 
         numpyro.factor("ll", ln_likelihood(params))
-
     return discovery_model

--- a/src/ptarcade/signal_builder.py
+++ b/src/ptarcade/signal_builder.py
@@ -1,6 +1,7 @@
 """Module for building PTA signals."""
 from __future__ import annotations
 
+import inspect
 import logging
 import sys
 from importlib.resources import files
@@ -8,7 +9,9 @@ from pathlib import Path
 from types import ModuleType
 from zipfile import ZipFile
 
+import discovery as ds
 import numpy as np
+import numpyro
 from astropy.utils.data import download_file
 from ceffyl import Ceffyl
 from enterprise import constants as const
@@ -23,13 +26,15 @@ from enterprise_extensions.blocks import (common_red_noise_block,
                                           white_noise_block)
 from enterprise_extensions.sampler import get_parameter_groups
 from numpy.typing import NDArray
+from numpyro import distributions as dist
 
-import ptarcade.models_utils as aux
 import ptarcade.ent_mod as mods
+import ptarcade.models_utils as aux
 
 log = logging.getLogger("rich")
 
-# gaussian parameters for the SMBHB signal. 
+
+# gaussian parameters for the SMBHB signal.
 # NG15 parameters are extracted from the holodeck library astro-02-gw
 # IPTA2 parameters are taken from Middleton et al. 2021
 bhb_priors = {"NG15" : [np.array([-15.61492963, 4.70709637]), np.array([[0.27871359, -0.00263617], [-0.00263617, 0.12415383]])],
@@ -100,7 +105,7 @@ def powerlaw2(f: NDArray, log10_Agamma: NDArray, components: int = 2) -> NDArray
 
 @parameter.function
 def powerlaw(f, Tspan, log10_A, gamma):
-    
+
     """Modified powerlaw function.
 
     Powerlaw function modified to work with ceffyl.
@@ -122,7 +127,7 @@ def powerlaw(f, Tspan, log10_A, gamma):
         The modified powerlaw.
 
     """
-    
+
     return (
         (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) / Tspan  # divide by Tspan here
     )
@@ -276,7 +281,7 @@ def ent_builder(
 
         if bhb_th_prior and (pta_dataset == "NG15" or pta_dataset == "IPTA2"):
 
-            mu, sigma = bhb_priors[pta_dataset]            
+            mu, sigma = bhb_priors[pta_dataset]
 
             if model is None:
                 log10_Agamma_gw = parameter.Normal(mu=mu, sigma=sigma, size=2)("gw_bhb")
@@ -333,18 +338,18 @@ def ent_builder(
     if model:
         if hasattr(model, "signal"):
             signal = function(model.signal)
-            signal = signal(**model.parameters)
+            signal = signal(**{key:val["enterprise_prior_obj"] for key,val in model.parameters.items()})
             np_signal = deterministic_signals.Deterministic(signal, name=model.name)
 
             s += np_signal
 
         elif hasattr(model, "spectrum"):
-            spectrum = aux.omega2cross(model.spectrum)
-            cpl_np = spectrum(**model.parameters)
+            spectrum = aux.omega2cross(model.spectrum, likelihood="enterprise")
+            cpl_np = spectrum(**{key:val["enterprise_prior_obj"] for key,val in model.parameters.items()})
 
             if corr and hasattr(model, "orf"):
                 orf = function(model.orf)
-                orf = orf(**model.parameters)
+                orf = orf(**{key:val["enterprise_prior_obj"] for key,val in model.parameters.items()})
 
                 np_gwb = mods.FourierBasisCommonGP(
                     spectrum=cpl_np,
@@ -390,7 +395,7 @@ def ent_builder(
             s2 += chrom.dm_exponential_dip(tmin=54500, tmax=55000, idx=2, sign=False, name="dmexp_1")
             if p.toas.max() / const.day > 57850:
                 s2 += chrom.dm_exponential_dip(tmin=57300, tmax=57850, idx=2, sign=False, name="dmexp_2")
-        
+
         models.append(s2(p))
 
     # set up PTA
@@ -528,11 +533,11 @@ def ceffyl_builder(inputs):
     model = []
 
     model.append(Ceffyl.signal(N_freqs=inputs["config"].gwb_components,
-                          psd=aux.omega2cross(inputs["model"].spectrum, ceffyl=True),  
+                          psd=aux.omega2cross(inputs["model"].spectrum, likelihood="ceffyl"),
                           params=params,
                           name=''))
-    
-    
+
+
     if inputs["model"].smbhb:
         mu, sigma = bhb_priors.get(inputs["config"].pta_data, np.array([False, False]))
 
@@ -561,11 +566,95 @@ def ceffyl_builder(inputs):
             bhb_params = [log10_A_bhb, gamma_bhb]
             bhb_signal = powerlaw
 
-            
+
         model.append(Ceffyl.signal(N_freqs=inputs["config"].gwb_components,
-                          psd=bhb_signal,  
+                          psd=bhb_signal,
                           params=bhb_params,
                           name=''))
 
     ceffyl_pta.add_signals(model)
     return ceffyl_pta
+
+def discovery_builder(
+    psrs: list[ds.Pulsar],
+    model: ModuleType,
+    corr: bool = False,
+    red_components: int = 30,
+    gwb_components: int = 14,
+) -> ds.ArrayLikelihood:
+    globalgp_psd = aux.omega2cross(model.spectrum, likelihood="discovery")
+    globalgp_psd.__signature__ = inspect.signature(model.spectrum)
+
+    Tspan = ds.getspan(psrs)
+
+    pslmodels = (
+        ds.PulsarLikelihood(
+            [
+                psr.residuals,
+                ds.makenoise_measurement(psr, psr.noisedict),
+                ds.makegp_ecorr(psr, psr.noisedict),
+                ds.makegp_timing(psr, svd=True),
+            ]
+        )
+        for psr in psrs
+    )
+
+    rngp = ds.makecommongp_fourier(psrs, ds.powerlaw, red_components, T=Tspan, name="red_noise")
+    if corr:
+        hdgp = ds.makeglobalgp_fourier(psrs, globalgp_psd, ds.hd_orf, gwb_components, T=Tspan, name=model.name)
+        return ds.ArrayLikelihood(pslmodels, commongp=rngp, globalgp=hdgp)
+
+    curngp = ds.makecommongp_fourier(
+        psrs,
+        globalgp_psd,
+        gwb_components,
+        T=Tspan,
+        common=list(model.parameters),
+        name=model.name,
+    )
+    return ds.ArrayLikelihood(pslmodels, commongp=[rngp, curngp])
+
+
+def discovery_numpyro_model_builder(
+    psrs: list[ds.Pulsar],
+    inputs: dict[str, ModuleType],
+    likelihood_obj: ds.ArrayLikelihood,
+    noisedict: dict | None = None,
+    pta_dataset: str | None = None,
+    bhb_th_prior: bool = False,
+    gamma_bhb: float | None = None,
+    A_bhb_logmin: float | None = None,
+    A_bhb_logmax: float | None = None,
+) -> ds.ArrayLikelihood:
+    ln_likelihood = likelihood_obj.logL
+    params = ln_likelihood.params
+
+
+    red_noise_gamma_params = []
+    red_noise_amp_params = []
+
+    for p in params:
+        if "red_noise_log10_A" in p:
+            red_noise_amp_params.append(p)
+        elif "red_noise_gamma" in p:
+            red_noise_gamma_params.append(p)
+
+    def discovery_model():
+        # Get new physics priors
+        params = {
+            (f"{inputs['model'].name}_{par}" if inputs["config"].corr else par): numpyro.sample(par, aux.get_numpyro_prior(val["name"], *val["args"], **val["kwargs"]))
+            for par, val in inputs["model"].parameters.items()
+        }
+
+        # Pulsar red noise priors
+        for amp, gam in zip(red_noise_amp_params, red_noise_gamma_params, strict=True):
+            params.update(
+                {
+                    amp: numpyro.sample(amp, dist.Uniform(-20, -11)),
+                    gam: numpyro.sample(gam, dist.Uniform(0, 7)),
+                }
+            )
+
+        numpyro.factor("ll", ln_likelihood(params))
+
+    return discovery_model

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 1
 requires-python = ">=3.9, <3.13"
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version == '3.10.*'",
+    "python_full_version < '3.10'",
     "python_full_version == '3.11.*'",
     "python_full_version >= '3.12'",
 ]
@@ -351,6 +352,20 @@ wheels = [
 ]
 
 [[package]]
+name = "discovery"
+version = "0.5"
+source = { git = "https://github.com/nanograv/discovery.git#337665519eb64c238849beddcb691da1bfc89aef" }
+dependencies = [
+    { name = "jax", version = "0.4.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+
+[[package]]
 name = "emcee"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -696,7 +711,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641 }
 wheels = [
@@ -760,6 +775,111 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3e/48/d3dbac45c2814cb73812f98dd6b38bbcc957a4e7bb31d6ea9c03bf94ed87/ipywidgets-8.1.7.tar.gz", hash = "sha256:15f1ac050b9ccbefd45dccfbb2ef6bed0029d8278682d569d71b8dd96bee0376", size = 116721 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/6a/9166369a2f092bd286d24e6307de555d63616e8ddb373ebad2b5635ca4cd/ipywidgets-8.1.7-py3-none-any.whl", hash = "sha256:764f2602d25471c213919b8a1997df04bef869251db4ca8efba1b76b1bd9f7bb", size = 139806 },
+]
+
+[[package]]
+name = "jax"
+version = "0.4.30"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "jaxlib", version = "0.4.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "ml-dtypes", marker = "python_full_version < '3.10'" },
+    { name = "numpy", marker = "python_full_version < '3.10'" },
+    { name = "opt-einsum", marker = "python_full_version < '3.10'" },
+    { name = "scipy", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/41/d6dbafc31d6bd93eeec2e1c709adfa454266e83714ebeeed9de52a6ad881/jax-0.4.30.tar.gz", hash = "sha256:94d74b5b2db0d80672b61d83f1f63ebf99d2ab7398ec12b2ca0c9d1e97afe577", size = 1715462 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/f2/9dbb75de3058acfd1600cf0839bcce7ea391148c9d2b4fa5f5666e66f09e/jax-0.4.30-py3-none-any.whl", hash = "sha256:289b30ae03b52f7f4baf6ef082a9f4e3e29c1080e22d13512c5ecf02d5f1a55b", size = 2009197 },
+]
+
+[[package]]
+name = "jax"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "ml-dtypes", marker = "python_full_version >= '3.10'" },
+    { name = "numpy", marker = "python_full_version >= '3.10'" },
+    { name = "opt-einsum", marker = "python_full_version >= '3.10'" },
+    { name = "scipy", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/1e/267f59c8fb7f143c3f778c76cb7ef1389db3fd7e4540f04b9f42ca90764d/jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96", size = 2334091 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a8/97ef0cbb7a17143ace2643d600a7b80d6705b2266fc31078229e406bdef2/jax-0.6.2-py3-none-any.whl", hash = "sha256:bb24a82dc60ccf704dcaf6dbd07d04957f68a6c686db19630dd75260d1fb788c", size = 2722396 },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.4.30"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "ml-dtypes", marker = "python_full_version < '3.10'" },
+    { name = "numpy", marker = "python_full_version < '3.10'" },
+    { name = "scipy", marker = "python_full_version < '3.10'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/18/ff7f2f6d6195853ed55c5b5d835f5c8c3c8b190c7221cb04a0cb81f5db10/jaxlib-0.4.30-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:c40856e28f300938c6824ab1a615166193d6997dec946578823f6d402ad454e5", size = 83542097 },
+    { url = "https://files.pythonhosted.org/packages/d4/c0/ff65503ecfed3aee11e4abe4c4e9e8a3513f072e0b595f8247b9989d1510/jaxlib-0.4.30-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4bdfda6a3c7a2b0cc0a7131009eb279e98ca4a6f25679fabb5302dd135a5e349", size = 66694495 },
+    { url = "https://files.pythonhosted.org/packages/b9/d7/82df748a31a1cfbd531a12979ea846d6b676d4adfa1e91114b848665b2aa/jaxlib-0.4.30-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:28e032c9b394ab7624d89b0d9d3bbcf4d1d71694fe8b3e09d3fe64122eda7b0c", size = 67781242 },
+    { url = "https://files.pythonhosted.org/packages/4a/ca/561aabed63007bb2621a62f0d816aa2f68cfe947859c8b4e61519940344b/jaxlib-0.4.30-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:d83f36ef42a403bbf7c7f2da526b34ba286988e170f4df5e58b3bb735417868c", size = 79640266 },
+    { url = "https://files.pythonhosted.org/packages/b0/90/8e5347eda95d3cb695cd5ebb82f850fa7866078a6a7a0568549e34125a82/jaxlib-0.4.30-cp310-cp310-win_amd64.whl", hash = "sha256:a56678b28f96b524ded6da8ef4b38e72a532356d139cfd434da804abf4234e14", size = 51945307 },
+    { url = "https://files.pythonhosted.org/packages/33/2d/b6078f5d173d3087d32b1b49e5f65d406985fb3894ff1d21905972b9c89d/jaxlib-0.4.30-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:bfb5d85b69c29c3c6e8051a0ea715ac1e532d6e54494c8d9c3813dcc00deac30", size = 83539315 },
+    { url = "https://files.pythonhosted.org/packages/12/95/399da9204c3b13696baefb93468402f3389416b0caecfd9126aa94742bf2/jaxlib-0.4.30-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:974998cd8a78550402e6c09935c1f8d850cad9cc19ccd7488bde45b6f7f99c12", size = 66690971 },
+    { url = "https://files.pythonhosted.org/packages/a4/f8/b85a46cb0cc4bc228cea4366b0d15caf42656c6d43cf8c91d90f7399aa4d/jaxlib-0.4.30-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:e93eb0646b41ba213252b51b0b69096b9cd1d81a35ea85c9d06663b5d11efe45", size = 67780747 },
+    { url = "https://files.pythonhosted.org/packages/a6/a3/951da3d1487b2f8995a2a14cc7e9496c9a7c93aa1f1d0b33e833e24dee92/jaxlib-0.4.30-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:16b2ab18ea90d2e15941bcf45de37afc2f289a029129c88c8d7aba0404dd0043", size = 79640352 },
+    { url = "https://files.pythonhosted.org/packages/bb/1a/8f45ea28a5ca67e4d23ebd70fc78ea94be6fa20323f983c7607c32c6f9a5/jaxlib-0.4.30-cp311-cp311-win_amd64.whl", hash = "sha256:3a2e2c11c179f8851a72249ba1ae40ae817dfaee9877d23b3b8f7c6b7a012f76", size = 51943960 },
+    { url = "https://files.pythonhosted.org/packages/19/40/ae943d3c1fc8b50947aebbaa3bad2842759e43bc9fc91e1758c1c20a81ab/jaxlib-0.4.30-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:7704db5962b32a2be3cc07185433cbbcc94ed90ee50c84021a3f8a1ecfd66ee3", size = 83587124 },
+    { url = "https://files.pythonhosted.org/packages/c6/e3/97f8edff6f64245a500415be021869522b235e8b38cd930d358b91243583/jaxlib-0.4.30-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:57090d33477fd0f0c99dc686274882ea75c44c7d712ae42dd2460b10f896131d", size = 66724768 },
+    { url = "https://files.pythonhosted.org/packages/4c/c7/ee1f48f8daa409d0ed039e0d8b5ae1a447e53db3acb2ff06239828ad96d5/jaxlib-0.4.30-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:0a3850e76278038e21685975a62b622bcf3708485f13125757a0561ee4512940", size = 67800348 },
+    { url = "https://files.pythonhosted.org/packages/f2/fa/a2dddea0d6965b8e433bb99aeedbe5c8a9b47110c1c4f197a7b6239daf44/jaxlib-0.4.30-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:c58a8071c4e00898282118169f6a5a97eb15a79c2897858f3a732b17891c99ab", size = 79674030 },
+    { url = "https://files.pythonhosted.org/packages/db/31/3500633d61b20b882a0fbcf8100013195c31b51f71249b0b38737851fc9a/jaxlib-0.4.30-cp312-cp312-win_amd64.whl", hash = "sha256:b7079a5b1ab6864a7d4f2afaa963841451186d22c90f39719a3ff85735ce3915", size = 51965689 },
+    { url = "https://files.pythonhosted.org/packages/46/12/9de601dbae3c66666eeaaf5a28683d947909c046880baef390b7cd1d4b1d/jaxlib-0.4.30-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:ea3a00005faafbe3c18b178d3b534208b3b4027b2be6230227e7b87ce399fc29", size = 83544602 },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/2d417a1445d5e696bb44d564c7519d4a6761db4d3e31712620c510ed0127/jaxlib-0.4.30-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3d31e01191ce8052bd611aaf16ff967d8d0ec0b63f1ea4b199020cecb248d667", size = 66695975 },
+    { url = "https://files.pythonhosted.org/packages/e4/f9/e29370046f4648bd464df7eceaebbbaefd091cc88c77da4a6e3a5f1a00d7/jaxlib-0.4.30-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:11602d5556e8baa2f16314c36518e9be4dfae0c2c256a361403fb29dc9dc79a4", size = 67784388 },
+    { url = "https://files.pythonhosted.org/packages/07/3b/a596036325666624ca084df554636fb3777e78e9386b52476d96fa14394e/jaxlib-0.4.30-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f74a6b0e09df4b5e2ee399ebb9f0e01190e26e84ccb0a758fadb516415c07f18", size = 79643370 },
+    { url = "https://files.pythonhosted.org/packages/8a/a3/7342ceb02e49803af9a42ab3ad9b6c272cf7b2a83163e3a06859360012d5/jaxlib-0.4.30-cp39-cp39-win_amd64.whl", hash = "sha256:54987e97a22db70f3829b437b9329e4799d653634bacc8b398554d3b90c76b2a", size = 51946140 },
+]
+
+[[package]]
+name = "jaxlib"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.10.*'",
+    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "ml-dtypes", marker = "python_full_version >= '3.10'" },
+    { name = "numpy", marker = "python_full_version >= '3.10'" },
+    { name = "scipy", marker = "python_full_version >= '3.10'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/c5/41598634c99cbebba46e6777286fb76abc449d33d50aeae5d36128ca8803/jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8", size = 54298019 },
+    { url = "https://files.pythonhosted.org/packages/81/af/db07d746cd5867d5967528e7811da53374e94f64e80a890d6a5a4b95b130/jaxlib-0.6.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4205d098ce8efb5f7fe2fe5098bae6036094dc8d8829f5e0e0d7a9b155326336", size = 79440052 },
+    { url = "https://files.pythonhosted.org/packages/7e/d8/b7ae9e819c62c1854dbc2c70540a5c041173fbc8bec5e78ab7fd615a4aee/jaxlib-0.6.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:c087a0eb6fb7f6f8f54d56f4730328dfde5040dd3b5ddfa810e7c28ea7102b42", size = 89917034 },
+    { url = "https://files.pythonhosted.org/packages/fd/e5/87e91bc70569ac5c3e3449eefcaf47986e892f10cfe1d5e5720dceae3068/jaxlib-0.6.2-cp310-cp310-win_amd64.whl", hash = "sha256:153eaa51f778b60851720729d4f461a91edd9ba3932f6f3bc598d4413870038b", size = 57896337 },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/6899b0aed36a4acc51319465ddd83c7c300a062a9e236cceee00984ffe0b/jaxlib-0.6.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a208ff61c58128d306bb4e5ad0858bd2b0960f2c1c10ad42c548f74a60c0020e", size = 54300346 },
+    { url = "https://files.pythonhosted.org/packages/e6/03/34bb6b346609079a71942cfbf507892e3c877a06a430a0df8429c455cebc/jaxlib-0.6.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:11eae7e05bc5a79875da36324afb9eddd4baeaef2a0386caf6d4f3720b9aef28", size = 79438425 },
+    { url = "https://files.pythonhosted.org/packages/80/02/49b05cbab519ffd3cb79586336451fbbf8b6523f67128a794acc9f179000/jaxlib-0.6.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:335d7e3515ce78b52a410136f46aa4a7ea14d0e7d640f34e1e137409554ad0ac", size = 89920354 },
+    { url = "https://files.pythonhosted.org/packages/a7/7a/93b28d9452b46c15fc28dd65405672fc8a158b35d46beabaa0fe9631afb0/jaxlib-0.6.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6815509997d6b05e5c9daa7994b9ad473ce3e8c8a17bdbbcacc3c744f76f7a0", size = 57895707 },
+    { url = "https://files.pythonhosted.org/packages/ac/db/05e702d2534e87abf606b1067b46a273b120e6adc7d459696e3ce7399317/jaxlib-0.6.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:34d8a684a8be949dd87dd4acc97101b4106a0dc9ad151ec891da072319a57b99", size = 54301644 },
+    { url = "https://files.pythonhosted.org/packages/0d/8a/b0a96887b97a25d45ae2c30e4acecd2f95acd074c18ec737dda8c5cc7016/jaxlib-0.6.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:87ec2dc9c3ed9ab936eec8535160c5fbd2c849948559f1c5daa75f63fabe5942", size = 79439161 },
+    { url = "https://files.pythonhosted.org/packages/ba/e8/71c2555431edb5dd115cf86a7b599aa7e1be26728d89ae59aa11251d299c/jaxlib-0.6.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:f1dd09b481a93c1d4c750013f467f74194493ba7bd29fcd4d1cec16e3a214f65", size = 89942952 },
+    { url = "https://files.pythonhosted.org/packages/de/3a/06849113c844b86d20174df54735c84202ccf82cbd36d805f478c834418b/jaxlib-0.6.2-cp312-cp312-win_amd64.whl", hash = "sha256:921dbd4db214eba19a29ba9f2450d880e08b2b2c7b968f28cc89da3e62366af4", size = 57919603 },
 ]
 
 [[package]]
@@ -832,24 +952,32 @@ sdist = { url = "https://files.pythonhosted.org/packages/60/a4/ee1680051ef29215e
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/52/5ff42853ade0365d4f7a1335c829d037c2b95a24e44db2a781379a8f5e76/kdepy-1.1.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:aea3587396e458b53c63c8a070505bcd7fd7e60756f99d3390ee344e22d08f41", size = 269631 },
     { url = "https://files.pythonhosted.org/packages/de/24/9ca4380a635ab07b41522e9a8146ddcfa9c6a2d3330c721fa32bf4c3f64e/kdepy-1.1.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:64a837b0c552d681ef7bdfa5b0e18bbbc66e3d5dac7ad7fc9919c881e0f16498", size = 265061 },
+    { url = "https://files.pythonhosted.org/packages/b7/18/b53890d889f45836685d21ed5315152a515266df11874af9f38849522106/kdepy-1.1.12-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35b09bf8bded71ff5c90b03495529aa26b8c469ac8dc8cb1186f95999e4eef36", size = 687187 },
+    { url = "https://files.pythonhosted.org/packages/5d/d1/4c1bb8cf8e4d73a7094d3a731df9b153cd23d32781d977daa66a7eec9c4e/kdepy-1.1.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3a6421b24c5b11b700a7281c750c2ef170a75facb2c38a3aecb2cc77b1095308", size = 690427 },
     { url = "https://files.pythonhosted.org/packages/ee/b2/78d97b9b291a34a9905e5796a6830e984de843de1570cd8002796c4e2566/kdepy-1.1.12-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff27b711d3e914da68a80bdd8044d7992a9a48be090378be246f6b39d91b6e46", size = 652108 },
     { url = "https://files.pythonhosted.org/packages/63/5a/596c179ca5cfc6d137b6d2b2b48106371ba475c1b264834d8097707f4721/kdepy-1.1.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3fccc80e33e291752d2cee7686628c19f066806b9b3f62d7d007c09c252c8fc", size = 656824 },
     { url = "https://files.pythonhosted.org/packages/5b/48/c7f11143dc2e158ea4f814debc22d1cdcfae3406f05bdb82ea56a1a7d486/kdepy-1.1.12-cp310-cp310-win32.whl", hash = "sha256:d3839f95cfd45084901a0d9c98b4ac83a5eb57449a6be7004d422cf29d9eedff", size = 249688 },
     { url = "https://files.pythonhosted.org/packages/08/6c/459fbef9332423af790bc03d9cfccb2e3868b09cd17c71da8b12216bcc05/kdepy-1.1.12-cp310-cp310-win_amd64.whl", hash = "sha256:c7c5b091e3034d026bcf718a5efecbe2a1eee5100d1328621387d7fadb164dd8", size = 262081 },
     { url = "https://files.pythonhosted.org/packages/66/61/211c8c0e63943c2274ea87c15f3a1e18d253eb71b783166a3219f66c8ec9/kdepy-1.1.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4f7deb921bbe944247bf8c4d2b2078dd67be8130d3be4a32f947766daed60095", size = 269809 },
     { url = "https://files.pythonhosted.org/packages/26/a6/7559ae97ec9a178899469eb8d5fff49ef9cff53bbabacf2a986ef9e6dd03/kdepy-1.1.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b2f04a95a6d706ab6fcfba104c49b97e4b6ade40212bcface291e4ab6747eed0", size = 265130 },
+    { url = "https://files.pythonhosted.org/packages/56/4b/2c80748ddc64a01d1019b3ad1048d5544a90ed1b6e8e512094c299b0434c/kdepy-1.1.12-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59bd3d7b39ca3f7fb98dac7f72ea537b552f48ea008523ab862c38077f90c1b6", size = 712935 },
+    { url = "https://files.pythonhosted.org/packages/91/6f/0e5bfbe6bdf53850494ef7a5256dec72a431bdf003fa583ed2516eddbb23/kdepy-1.1.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b20ba0cc6e2864b0b831baa71f556ccc21005c5cc63a608cb21e0aa6c8317d64", size = 717292 },
     { url = "https://files.pythonhosted.org/packages/24/ab/83658a77d77de77e72785bebe3c26a3c99583bca269223a805b19c6eaa95/kdepy-1.1.12-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e5115b65531d36ab48b9e9dd952221bb7789999f95c7b44564367f885f5ade5", size = 686249 },
     { url = "https://files.pythonhosted.org/packages/db/40/075110da71dd4240205803d8533ea588e6ed929d42d96c08764b5eecf93e/kdepy-1.1.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1928bf44c9ee7f78239461d5670e8515f5d4a201eff5622547967c7c20fa82d", size = 691483 },
     { url = "https://files.pythonhosted.org/packages/6e/76/570c619625ac546fcbb5b4d7b1d8d928dd9eaad7dba03b07898e7b710d33/kdepy-1.1.12-cp311-cp311-win32.whl", hash = "sha256:1089bbdc007c0495556d6409f7c9235abfc79071c7147781ca6f644aad4e5eb4", size = 249361 },
     { url = "https://files.pythonhosted.org/packages/08/f4/b83f74465c9923e32b0c0bf038aa50551908fde7c95865ba63101c781c2d/kdepy-1.1.12-cp311-cp311-win_amd64.whl", hash = "sha256:ff6a4db7b40a63b9accde48ebfd25e664138f37eda56ad1be34fe37f60ce3d84", size = 262249 },
     { url = "https://files.pythonhosted.org/packages/80/ec/b27b63a6fe7165d6679bfc6f62e73b56d8b6ad0377d0703c53493649a5a1/kdepy-1.1.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:35bdfc7f046014b6bdf83d6d14b2adbd8f08c1d3b83d63a91d74970dc8085972", size = 271481 },
     { url = "https://files.pythonhosted.org/packages/f7/2e/5e4eb6fdb929f293b6e3db55eb021d09b51bafb71104ea0e73acd6f21b7e/kdepy-1.1.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e9ffa424aa96988a9b7f0154168c17cf64cba46ad691a556e77e51cae7992864", size = 266528 },
+    { url = "https://files.pythonhosted.org/packages/03/9a/98cb054c590e6d54f734630e4b6741fe0710127b74f6f0e7b0cfd1acc5c9/kdepy-1.1.12-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f4c80ef3e3f76d7106e538ae55b49c23e952a38eb34eba244bf82dd4dc98601", size = 712320 },
+    { url = "https://files.pythonhosted.org/packages/50/4a/38afaaf5e8fa20c46b292412beb2b4d944444bc345f191da5f8451f6b908/kdepy-1.1.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97213c678837e5baf2840e9e2f0e7ed64901c2758e80dccffcb1caae1c9b254a", size = 725770 },
     { url = "https://files.pythonhosted.org/packages/0d/45/95c70b4934690e69ab74b4f165b6c87609399253f2fa57d13b9441aa0975/kdepy-1.1.12-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6a98453558eb39fe093601dea19769ebb13e371e11a212be516b27b4f059a55", size = 676186 },
     { url = "https://files.pythonhosted.org/packages/8c/a1/7d3ab60c558d70fef89b92f27f51f361d8107b2b5f7ec2fab0d20531a1ec/kdepy-1.1.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e5d59f51dd1797b7729e09993986f2920f45e62609c3704c5946aa5f05171f1", size = 686217 },
     { url = "https://files.pythonhosted.org/packages/09/bd/390672f54d60c7f8094bdab68eca586e062fb97b622db9da3e97cc17fc2e/kdepy-1.1.12-cp312-cp312-win32.whl", hash = "sha256:2b00d31897ce5c88362149a5651048e594a5c0f7db7b85f0ace7767604bf004f", size = 250282 },
     { url = "https://files.pythonhosted.org/packages/c8/5e/30b7fe14f16e331ccc68331dda83567200e691baffa5ccc60aa326499034/kdepy-1.1.12-cp312-cp312-win_amd64.whl", hash = "sha256:0834ff21a74fbd85ee748a8e9ff0edc886e0dd2c9a7011d4f69a943029a61e3d", size = 263179 },
     { url = "https://files.pythonhosted.org/packages/8b/2b/765a30a636fbe7e87aa9ca96dd500fc8596369fca9157c5963ce31ac35a2/kdepy-1.1.12-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:34ba64f462127e2dc6a1de9ae4a742785cc97acf9fc9922a1378e3087e19c494", size = 270196 },
     { url = "https://files.pythonhosted.org/packages/1b/bd/8cd77fca66031f1ed236a32686b739c3030d6cf48010a27d43b1b4f68e16/kdepy-1.1.12-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b0cf62dc5a255075a5813965a58ac16b8b1144d538760bccf06ac529720db61e", size = 265571 },
+    { url = "https://files.pythonhosted.org/packages/51/40/3e89b46fa689d3d318868ab6fd64f5e2463d34954d20c9c57f9d3636a09e/kdepy-1.1.12-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e154db86db4046c8603a80c841b31d603de85ff8341440c6229b4f1d09ea22f1", size = 685710 },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c3a4bbd4e5845802c43a104eedc76f12fa46a9007273538cbb049a3214e0/kdepy-1.1.12-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:444ee4eb41ad31c605a7216f863ddbd20db3cff9069f7f3113f56d20714482c6", size = 688994 },
     { url = "https://files.pythonhosted.org/packages/f9/a9/348cde6a0123f6f09d53119bbb91b687b396f3f1c54093e98a0b6f6e1f26/kdepy-1.1.12-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e22ea5a38278e86be531e87da07026a7aaa0450fdf7b8f6e8813ef9c04e5de0", size = 654901 },
     { url = "https://files.pythonhosted.org/packages/92/07/8b8bf172b2eb09458801536ec3cdb4a79654ef18c729115f31a9f85ca810/kdepy-1.1.12-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d9a4ffcf155f4fa7e45e3ff33a8436e16a8e405fa8bd610803a697dc0dd6392", size = 659739 },
     { url = "https://files.pythonhosted.org/packages/f6/68/765751673c9e18e21695a9787b4b2e20095ea749dc27df9716b7babf0ce1/kdepy-1.1.12-cp39-cp39-win32.whl", hash = "sha256:94b555ec63d953ea3fb3b5a00fe7e7efadd7881cc6fe817551df913d38796de2", size = 250236 },
@@ -1313,6 +1441,35 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/a7/aad060393123cfb383956dca68402aff3db1e1caffd5764887ed5153f41b/ml_dtypes-0.5.3.tar.gz", hash = "sha256:95ce33057ba4d05df50b1f3cfefab22e351868a843b3b15a46c65836283670c9", size = 692316 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/bb/1f32124ab6d3a279ea39202fe098aea95b2d81ef0ce1d48612b6bf715e82/ml_dtypes-0.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0a1d68a7cb53e3f640b2b6a34d12c0542da3dd935e560fdf463c0c77f339fc20", size = 667409 },
+    { url = "https://files.pythonhosted.org/packages/1d/ac/e002d12ae19136e25bb41c7d14d7e1a1b08f3c0e99a44455ff6339796507/ml_dtypes-0.5.3-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cd5a6c711b5350f3cbc2ac28def81cd1c580075ccb7955e61e9d8f4bfd40d24", size = 4960702 },
+    { url = "https://files.pythonhosted.org/packages/dd/12/79e9954e6b3255a4b1becb191a922d6e2e94d03d16a06341ae9261963ae8/ml_dtypes-0.5.3-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bdcf26c2dbc926b8a35ec8cbfad7eff1a8bd8239e12478caca83a1fc2c400dc2", size = 4933471 },
+    { url = "https://files.pythonhosted.org/packages/d5/aa/d1eff619e83cd1ddf6b561d8240063d978e5d887d1861ba09ef01778ec3a/ml_dtypes-0.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:aecbd7c5272c82e54d5b99d8435fd10915d1bc704b7df15e4d9ca8dc3902be61", size = 206330 },
+    { url = "https://files.pythonhosted.org/packages/af/f1/720cb1409b5d0c05cff9040c0e9fba73fa4c67897d33babf905d5d46a070/ml_dtypes-0.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4a177b882667c69422402df6ed5c3428ce07ac2c1f844d8a1314944651439458", size = 667412 },
+    { url = "https://files.pythonhosted.org/packages/6a/d5/05861ede5d299f6599f86e6bc1291714e2116d96df003cfe23cc54bcc568/ml_dtypes-0.5.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9849ce7267444c0a717c80c6900997de4f36e2815ce34ac560a3edb2d9a64cd2", size = 4964606 },
+    { url = "https://files.pythonhosted.org/packages/db/dc/72992b68de367741bfab8df3b3fe7c29f982b7279d341aa5bf3e7ef737ea/ml_dtypes-0.5.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3f5ae0309d9f888fd825c2e9d0241102fadaca81d888f26f845bc8c13c1e4ee", size = 4938435 },
+    { url = "https://files.pythonhosted.org/packages/81/1c/d27a930bca31fb07d975a2d7eaf3404f9388114463b9f15032813c98f893/ml_dtypes-0.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:58e39349d820b5702bb6f94ea0cb2dc8ec62ee81c0267d9622067d8333596a46", size = 206334 },
+    { url = "https://files.pythonhosted.org/packages/1a/d8/6922499effa616012cb8dc445280f66d100a7ff39b35c864cfca019b3f89/ml_dtypes-0.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:66c2756ae6cfd7f5224e355c893cfd617fa2f747b8bbd8996152cbdebad9a184", size = 157584 },
+    { url = "https://files.pythonhosted.org/packages/0d/eb/bc07c88a6ab002b4635e44585d80fa0b350603f11a2097c9d1bfacc03357/ml_dtypes-0.5.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:156418abeeda48ea4797db6776db3c5bdab9ac7be197c1233771e0880c304057", size = 663864 },
+    { url = "https://files.pythonhosted.org/packages/cf/89/11af9b0f21b99e6386b6581ab40fb38d03225f9de5f55cf52097047e2826/ml_dtypes-0.5.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1db60c154989af253f6c4a34e8a540c2c9dce4d770784d426945e09908fbb177", size = 4951313 },
+    { url = "https://files.pythonhosted.org/packages/d8/a9/b98b86426c24900b0c754aad006dce2863df7ce0bb2bcc2c02f9cc7e8489/ml_dtypes-0.5.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b255acada256d1fa8c35ed07b5f6d18bc21d1556f842fbc2d5718aea2cd9e55", size = 4928805 },
+    { url = "https://files.pythonhosted.org/packages/50/c1/85e6be4fc09c6175f36fb05a45917837f30af9a5146a5151cb3a3f0f9e09/ml_dtypes-0.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:da65e5fd3eea434ccb8984c3624bc234ddcc0d9f4c81864af611aaebcc08a50e", size = 208182 },
+    { url = "https://files.pythonhosted.org/packages/9e/17/cf5326d6867be057f232d0610de1458f70a8ce7b6290e4b4a277ea62b4cd/ml_dtypes-0.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:8bb9cd1ce63096567f5f42851f5843b5a0ea11511e50039a7649619abfb4ba6d", size = 161560 },
+    { url = "https://files.pythonhosted.org/packages/19/2d/c61af51173083bbf2a3b0f1a1a01d50ef1830436880027433d1b75271083/ml_dtypes-0.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5ee72568d46b9533ad54f78b1e1f3067c0534c5065120ea8ecc6f210d22748b3", size = 663552 },
+    { url = "https://files.pythonhosted.org/packages/61/0e/a628f2aefd719745e8a13492375a55cedea77c0cfc917b1ce11bde435c68/ml_dtypes-0.5.3-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01de48de4537dc3c46e684b969a40ec36594e7eeb7c69e9a093e7239f030a28a", size = 4952704 },
+    { url = "https://files.pythonhosted.org/packages/f8/2e/5ba92f1f99d1f5f62bffec614a5b8161e55c3961257c902fa26dbe909baa/ml_dtypes-0.5.3-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b1a6e231b0770f2894910f1dce6d2f31d65884dbf7668f9b08d73623cdca909", size = 4923538 },
+    { url = "https://files.pythonhosted.org/packages/70/3b/f801c69027866ea6e387224551185fedef62ad8e2e71181ec0d9dda905f7/ml_dtypes-0.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:a4f39b9bf6555fab9bfb536cf5fdd1c1c727e8d22312078702e9ff005354b37f", size = 206567 },
+]
+
+[[package]]
 name = "mpi4py"
 version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1324,6 +1481,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/08/9e/db473d40bb7548cf2464d2b836d5f4afa075efa15765f9f51d27e7ea3ae1/mpi4py-4.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:a756e7e787a51c28773ae51f4b65f9aa78334ae020457965da9a48221cc125e9", size = 1587340 },
     { url = "https://files.pythonhosted.org/packages/57/ec/c18c4fcd4d664eaba26b1d73712d7c345a5e6eca39ba850aba23625f12f3/mpi4py-4.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:62ce21885fd94a7f9615a17d6d036098ca883178c4d7621c8f84a7a23d7d35b7", size = 1583516 },
     { url = "https://files.pythonhosted.org/packages/ce/01/04aec0e60d29da2a5e4968c95d075542a54a0673f21ce27c5ff5830cf430/mpi4py-4.0.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:324bc2a8b013b05d7ac7c96077f5bbcc78527446b07fad772a93adb0c74e4fbb", size = 1583391 },
+]
+
+[[package]]
+name = "multipledispatch"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/a62c3b824c7dec33c4a1578bcc842e6c30300051033a4e5975ed86cc2536/multipledispatch-1.0.0.tar.gz", hash = "sha256:5c839915465c68206c3e9c473357908216c28383b425361e5d144594bf85a7e0", size = 12385 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl", hash = "sha256:0c53cd8b077546da4e48869f49b13164bebafd0c2a5afceb6bb6a316e7fb46e4", size = 12818 },
 ]
 
 [[package]]
@@ -1430,6 +1596,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/72/3df6c1c06fc83d9cfe381cccb4be2532bbd38bf93fbc9fad087b6687f1c0/numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30", size = 20455961 },
     { url = "https://files.pythonhosted.org/packages/8e/02/570545bac308b58ffb21adda0f4e220ba716fb658a63c151daecc3293350/numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c", size = 18061071 },
     { url = "https://files.pythonhosted.org/packages/f4/5f/fafd8c51235f60d49f7a88e2275e13971e90555b67da52dd6416caec32fe/numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0", size = 15709730 },
+]
+
+[[package]]
+name = "numpyro"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax", version = "0.4.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jaxlib", version = "0.4.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "multipledispatch" },
+    { name = "numpy" },
+    { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/7c/5d1b55401b023b58f792483c71690315d4d5cd1653fd3631fa5bcbd68601/numpyro-0.19.0.tar.gz", hash = "sha256:bbf5b772a6ba8b7a79448fa6787afb069e5eb2dff8295078c3ec04d3e6276742", size = 404421 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/31/9b5da5995988437756bc3f1eead2e314d8916259875c6924cb41692f2b41/numpyro-0.19.0-py3-none-any.whl", hash = "sha256:1063a2c131a0785719e13c8e55f1b82e41850d814df149418097531f4dbdeda8", size = 370906 },
+]
+
+[[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932 },
 ]
 
 [[package]]
@@ -1626,14 +1820,18 @@ dependencies = [
     { name = "astroml" },
     { name = "astropy" },
     { name = "ceffyl" },
+    { name = "discovery" },
     { name = "encor" },
     { name = "enterprise-extensions" },
     { name = "enterprise-pulsar" },
     { name = "getdist" },
     { name = "h5py" },
+    { name = "jax", version = "0.4.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mpi4py" },
     { name = "natpy" },
     { name = "numpy" },
+    { name = "numpyro" },
     { name = "pandas" },
     { name = "ptmcmcsampler" },
     { name = "pyarrow" },
@@ -1664,14 +1862,17 @@ requires-dist = [
     { name = "astroml", specifier = ">=1.0.2.post1,<2.0.0" },
     { name = "astropy", specifier = ">=5.3.4" },
     { name = "ceffyl", specifier = ">=1.41.1,<1.50" },
+    { name = "discovery", git = "https://github.com/nanograv/discovery.git" },
     { name = "encor", specifier = ">=1.1.5,<2.0.0" },
     { name = "enterprise-extensions", specifier = ">=3.0.0,<4.0.0" },
     { name = "enterprise-pulsar", specifier = ">=3.4.3,<4.0.0" },
     { name = "getdist", specifier = ">=1.4.6,<2.0.0" },
     { name = "h5py", specifier = ">=3.8.0,<4.0.0" },
+    { name = "jax", specifier = ">=0.4.30" },
     { name = "mpi4py", specifier = ">=3.1.4,<5.0.0" },
     { name = "natpy", specifier = ">=0.1.1,<1.0.0" },
     { name = "numpy", specifier = ">=1.24.3,<3.0.0" },
+    { name = "numpyro", specifier = ">=0.19.0" },
     { name = "pandas", specifier = ">=2.0.2,<3.0.0" },
     { name = "ptmcmcsampler", specifier = ">=2.1.1,<3.0.0" },
     { name = "pyarrow", specifier = ">=12.0.0" },
@@ -2133,6 +2334,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
     { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
 ]
 
 [[package]]


### PR DESCRIPTION
# This is a work in progress, but I'm opening a draft so that people can test it!
## How to use?
Just set `mode=discovery` in your config. If you use `numpy` in your model file, import `jax.numpy` instead.
## What's currently implemented
- CURN and HD NANOGrav likelihoods. ArrayLikelihood to be specific. Fast on CPU, very fast on GPU
- Conversion from enterprise pulsars to feather pulsars cached on disk
  - This can use a large amount of memory. You can just place your feather files at `~/.ptarcade/cache/discovery_feather/<dataset>`, where `dataset` matches a PTArcade dataset name. It will just read them. 
- Any stochastic, non-interpolated signals implemented in JAX (just replace `numpy` with `jax.numpy` in your model file)
- Model utils written in `jax`
- `numpyro` model builder and NUTS sampler
- Mapping from existing prior dictionary to `numpyro` priors
- New data saving and loading routines. Just set `chain_name=chain_1.feather` when loading your chain instead of `chain_1.txt`
- Plots work
- GPU acceleration works. You will need to install the appropriate GPU extra/package for `jax` on your machine. 
  -  Apple Silicon: `jax-metal`
  - NVIDIA: `jax[cuda]`
  - AMD: `rocm-jax`

## What doesn't work/isn't implemented yet
- Model comparison (product space sampling)
- Pre-defined powerlaw PSD for SMBHB model (this isn't hard to do, I just haven't done it yet)
- DMGP or any other non-vanilla models
- Interpolated signals that use `fast_interpolate`
- Deterministic signals
- Proper bookkeeping for priors when saving to disk for later plotting/statistical analyses. For now, it writes your model file's priors properly but assumes that the only other parameters are red noise parameters with standard uniform priors.
- Installation of discovery from PyPI. I will change this before we merge.
- Documentation 
